### PR TITLE
Set node.js version to docker tag 18 in Dockerfile

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Node.js image as base image
-FROM node:16
+FROM node:18
 ARG ENV
 ENV ENV $ENV
 


### PR DESCRIPTION
current pnpm requires 18.12+

Without this patch, `docker compose build` produces (today):
```
 > [13/13] RUN CI=true pnpm i:
#0 1.370 ERROR: This version of pnpm requires at least Node.js v18.12
#0 1.370 The current version of Node.js is v16.20.2
#0 1.370 Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.
```