### PR TITLE
fix: absolute paths leads to errors when running `docker compose up`

### DIFF
--- a/sandbox/infrastructure/docker-compose.yml
+++ b/sandbox/infrastructure/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: "mongodb-sandbox"
     build:
       context: .
-      dockerfile: /utils/connector/mongodb/Dockerfile
+      dockerfile: ./utils/connector/mongodb/Dockerfile
     ports:
       - 27020:27017
     networks:
@@ -26,7 +26,7 @@ services:
     restart: unless-stopped
     tty: true
     env_file:
-      - /utils/provider/.env.provider
+      - ./utils/provider/.env.provider
     ports:
       - 3010:3000
     depends_on:
@@ -46,7 +46,7 @@ services:
     restart: unless-stopped
     tty: true
     env_file:
-      - /utils/consumer/.env.consumer
+      - ./utils/consumer/.env.consumer
     ports:
       - 3030:3001
     depends_on:
@@ -66,7 +66,7 @@ services:
     restart: unless-stopped
     tty: true
     env_file:
-      - /utils/infrastructure/.env.infrastructure
+      - ./utils/infrastructure/.env.infrastructure
     ports:
       - 3020:3002
     depends_on:
@@ -81,7 +81,7 @@ services:
     container_name: "consumer-api"
     build:
       context: .
-      dockerfile: /utils/consumer-api/Dockerfile
+      dockerfile: ./utils/consumer-api/Dockerfile
     ports:
       - "3031:8031"
     networks:
@@ -91,7 +91,7 @@ services:
     container_name: "provider-api"
     build:
       context: .
-      dockerfile: /utils/provider-api/Dockerfile
+      dockerfile: ./utils/provider-api/Dockerfile
     ports:
       - "3011:8011"
     networks:
@@ -101,7 +101,7 @@ services:
     container_name: "infrastructure-api"
     build:
       context: .
-      dockerfile: /utils/infrastructure-api/Dockerfile
+      dockerfile: ./utils/infrastructure-api/Dockerfile
     ports:
       - "3021:8021"
     networks:
@@ -111,7 +111,7 @@ services:
     container_name: "contract"
     build:
       context: .
-      dockerfile: /utils/contract/Dockerfile
+      dockerfile: ./utils/contract/Dockerfile
     ports:
       - "3001:8081"
     networks:
@@ -121,7 +121,7 @@ services:
     container_name: "catalog"
     build:
       context: .
-      dockerfile: /utils/catalog/Dockerfile
+      dockerfile: ./utils/catalog/Dockerfile
     ports:
       - "3002:8082"
     networks:
@@ -131,7 +131,7 @@ services:
     container_name: "consent"
     build:
       context: .
-      dockerfile: /utils/consent/Dockerfile
+      dockerfile: ./utils/consent/Dockerfile
     ports:
       - "3003:8083"
     networks:


### PR DESCRIPTION
Made all absolute paths relative, so it is possible to run the Docker Compose file 🙂 

Reference to issue here: #33 