### PR TITLE
[1.8.2] Use config.json by default

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "ptx-dataspace-connector",
-    "version": "1.8.0",
+    "version": "1.8.2",
     "description": "Prometheus-X Data Space Connector"
   },
   "paths": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ptx-dataspace-connector",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "description": "Prometheus-X Data Space Connector",
     "main": "src/index.ts",
     "engines": {

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
 import path from 'path';
+import fs from 'fs';
 
 export const config: {
     /**
@@ -64,9 +65,10 @@ export const config: {
 export const setupEnvironment = (customEnv?: string) => {
     let envArg = process.argv.find((arg) => arg.startsWith('--'));
     let envFile = '.env';
+    let configFile = 'config.json';
     if (customEnv) {
         envFile = `.env.${customEnv}`;
-        envArg = `--${customEnv}`
+        envArg = `--${customEnv}`;
     } else {
         if (envArg) {
             const envType = envArg.substring(2);
@@ -84,12 +86,19 @@ export const setupEnvironment = (customEnv?: string) => {
         env = dotenv.config({
             path: path.join(__dirname, '..', '..', '.env'),
         });
-        
+
         if (env.error) {
             throw new Error(
                 'Error initializing environment. Could not find .env file'
             );
         }
+    }
+
+    //Verify if configFile exisist
+    const customConfigFile = `config.${envArg.substring(2)}.json`;
+    const customConfigFilePath = path.join(__dirname, '..', customConfigFile);
+    if (fs.existsSync(customConfigFilePath)) {
+        configFile = customConfigFile;
     }
 
     config.env = process.env.NODE_ENV || config.env;
@@ -108,5 +117,5 @@ export const setupEnvironment = (customEnv?: string) => {
         process.env.WINSTON_LOGS_MAX_FILES || config.winstonLogsMaxFiles;
     config.winstonLogsMaxSize =
         process.env.WINSTON_LOGS_MAX_SIZE || config.winstonLogsMaxSize;
-    config.configurationFile = `config.${envArg.substring(2)}.json` || `config.json`
+    config.configurationFile = configFile;
 };


### PR DESCRIPTION
## Fix 
- added condition in environment.ts to check if the config file with specific environment exist, if not by default use the config.json

## chore
- version 1.8.2