### PR TITLE
Sandbox: disable wiremock healthcheck

### DIFF
--- a/sandbox/infrastructure/utils/catalog/Dockerfile
+++ b/sandbox/infrastructure/utils/catalog/Dockerfile
@@ -1,4 +1,5 @@
 # Dockerfile for WireMock
 FROM wiremock/wiremock:latest
 COPY /utils/catalog/stubs/ /home/wiremock/mappings
+HEALTHCHECK NONE
 ENTRYPOINT ["/docker-entrypoint.sh", "--global-response-templating", "--disable-gzip", "--verbose", "--port", "8082"]

--- a/sandbox/infrastructure/utils/consumer-api/Dockerfile
+++ b/sandbox/infrastructure/utils/consumer-api/Dockerfile
@@ -1,4 +1,5 @@
 # Dockerfile for WireMock
 FROM wiremock/wiremock:latest
 COPY /utils/consumer-api/stubs/ /home/wiremock/mappings
+HEALTHCHECK NONE
 ENTRYPOINT ["/docker-entrypoint.sh", "--global-response-templating", "--disable-gzip", "--verbose", "--port", "8031"]

--- a/sandbox/infrastructure/utils/contract/Dockerfile
+++ b/sandbox/infrastructure/utils/contract/Dockerfile
@@ -1,4 +1,5 @@
 # Dockerfile for WireMock
 FROM wiremock/wiremock:latest
 COPY /utils/contract/stubs/ /home/wiremock/mappings
+HEALTHCHECK NONE
 ENTRYPOINT ["/docker-entrypoint.sh", "--global-response-templating", "--disable-gzip", "--verbose", "--port", "8081"]

--- a/sandbox/infrastructure/utils/infrastructure-api/Dockerfile
+++ b/sandbox/infrastructure/utils/infrastructure-api/Dockerfile
@@ -1,4 +1,5 @@
 # Dockerfile for WireMock
 FROM wiremock/wiremock:latest
 COPY /utils/infrastructure-api/stubs/ /home/wiremock/mappings
+HEALTHCHECK NONE
 ENTRYPOINT ["/docker-entrypoint.sh", "--global-response-templating", "--disable-gzip", "--verbose", "--port", "8021"]

--- a/sandbox/infrastructure/utils/provider-api/Dockerfile
+++ b/sandbox/infrastructure/utils/provider-api/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for WireMock
 FROM wiremock/wiremock:latest
 COPY /utils/provider-api/stubs/ /home/wiremock/mappings
+HEALTHCHECK NONE
 ENTRYPOINT ["/docker-entrypoint.sh", "--global-response-templating", "--disable-gzip", "--verbose", "--port", "8011"]
-


### PR DESCRIPTION
The port configuration (`--port`) of wiremock-based images (latest/3.12.1) is not propagated to its iherited
[healtcheck command](https://hub.docker.com/r/wiremock/wiremock), thus it uses the default **8080** port in the test command's URL:

```json
"Healthcheck": {
                "Test": [
                    "CMD-SHELL",
                    "curl -f http://localhost:8080/__admin/health || exit 1"
                ],
                "StartPeriod": 5000000000,
                "StartInterval": 100000000
            },

```
This means all wiremock-based containers eventually become unhealthy, which can cause trouble in sandbox-based tests cases.

Possible solution could be to set the command explicitly, but it seems unnecessary in a sandbox environment.