### PR TITLE
[1.9.4] Fix update consent configuration and public key management

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ptx-dataspace-connector",
-    "version": "1.9.3",
+    "version": "1.9.4",
     "description": "Prometheus-X Data Space Connector",
     "main": "src/index.ts",
     "engines": {
@@ -24,7 +24,7 @@
         "lint": "eslint src/**/*.{ts,js}",
         "lint:fix": "eslint src/**/*.{ts,js} --fix",
         "postinstall": "git init && git config core.hooksPath ./.git-hooks && npm i -g semver",
-        "postbuild": "mkdirp dist/src/keys/ && mkdirp dist/docs/ && mkdirp dist/src/public/uploads",
+        "postbuild": "mkdirp dist/src/keys/ && mkdirp dist/docs/ && mkdirp dist/src/public/uploads && cp -r src/keys dist/src",
         "uid": "node uid.js",
         "generate-swagger": "ts-node generate-swagger.ts"
     },

--- a/src/controllers/private/v1/configuration.private.controller.ts
+++ b/src/controllers/private/v1/configuration.private.controller.ts
@@ -64,7 +64,7 @@ export const updateConsentConfiguration = async (
     try {
         const configuration = await updateConsentConfigurationService(
             req.body.uri,
-            req.body.key
+            req.body.publicKey
         );
         return restfulResponse(res, 200, configuration);
     } catch (err) {

--- a/src/services/private/v1/configuration.private.service.ts
+++ b/src/services/private/v1/configuration.private.service.ts
@@ -64,10 +64,43 @@ export const updateConsentConfigurationService = async (
 
     const publicKey = atob(key);
 
-    fs.writeFileSync(
-        path.join(__dirname, '..', '..', '..', './keys/consentSignature.pem'),
-        publicKey
-    );
+    if (__dirname.includes('dist')) {
+        const pathFile = path.join(__dirname, '..', '..', '..', './keys');
+        const pathFileSrc = path.join(
+            __dirname,
+            '..',
+            '..',
+            '..',
+            '..',
+            '..',
+            'src',
+            'keys'
+        );
+        fs.writeFileSync(
+            path.join(pathFile, './consentSignature.pem'),
+            publicKey
+        );
+
+        if (!fs.existsSync(path.join(pathFileSrc))) {
+            fs.mkdirSync(path.join(pathFileSrc));
+        }
+
+        fs.writeFileSync(
+            path.join(pathFileSrc, './consentSignature.pem'),
+            publicKey
+        );
+    } else {
+        const filePath = path.join(__dirname, '..', '..', '..', './keys');
+        if (!fs.existsSync(filePath)) {
+            fs.mkdirSync(filePath);
+        }
+
+        fs.writeFileSync(
+            path.join(filePath, './consentSignature.pem'),
+            publicKey
+        );
+    }
+
     return configuration;
 };
 


### PR DESCRIPTION
## Fix

* added command in postbuild to keep copying the existing public keys
* update the body paarams received by the consent
* added condition to always create the key in the src folder