### PR TITLE
[1.9.7] Fix paramsMapper test and Bilateral flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ptx-dataspace-connector",
-    "version": "1.9.6",
+    "version": "1.9.7",
     "description": "Prometheus-X Data Space Connector",
     "main": "src/index.ts",
     "engines": {

--- a/src/libs/loaders/representationFetcher.ts
+++ b/src/libs/loaders/representationFetcher.ts
@@ -296,7 +296,7 @@ export const getRepresentation = async (params: {
  * @return Promise<any>
  */
 export const postOrPutRepresentation = async (params: {
-    resource: string;
+    resource?: string;
     representationUrl: string;
     data: any;
     method: string;

--- a/src/services/public/v1/consumer.public.service.ts
+++ b/src/services/public/v1/consumer.public.service.ts
@@ -47,6 +47,10 @@ export const triggerBilateralFlow = async (props: {
         axios.get(contractResponse.serviceOffering)
     );
 
+    const [purposeResponse] = await handle(
+        axios.get(contractResponse.purpose[0].purpose)
+    );
+
     if (!providerResponse?.dataspaceEndpoint) {
         Logger.error({
             message: 'Provider missing PDC endpoint',
@@ -68,8 +72,8 @@ export const triggerBilateralFlow = async (props: {
 
     const mappedSoftwareResources = resourcesMapper({
         resources: purposes,
-        resourceResponse,
-        serviceOffering: contractResponse.serviceOffering,
+        resourceResponse: purposeResponse,
+        serviceOffering: contractResponse.purpose[0].purpose,
         type: 'softwareResources',
     });
 

--- a/src/tests/utils/paramsmapper.spec.ts
+++ b/src/tests/utils/paramsmapper.spec.ts
@@ -26,7 +26,8 @@ describe('Params Mapper', () => {
                 ],
                 status: 'PENDING',
             } as unknown as IDataExchange,
-            url: "https://test.com"
+            url: "https://test.com",
+            type: "providerParams"
         })
         expect(mapped).to.have.property('url', 'https://test.com');
     });
@@ -55,7 +56,8 @@ describe('Params Mapper', () => {
                 ],
                 status: 'PENDING',
             } as unknown as IDataExchange,
-            url: "https://test.com"
+            url: "https://test.com",
+            type: "providerParams"
         })
         expect(mapped).to.have.property('url', 'https://test.com?limit=25');
     });
@@ -84,7 +86,8 @@ describe('Params Mapper', () => {
                 ],
                 status: 'PENDING',
             } as unknown as IDataExchange,
-            url: "https://test.com?skip=2"
+            url: "https://test.com?skip=2",
+            type: "providerParams"
         })
         expect(mapped).to.have.property('url', 'https://test.com?skip=2&limit=25');
     });


### PR DESCRIPTION
## Fix
* updated postOrPutRepresentation params to not be mandatory
* updated test following updated made in 1.9.6
* updated Bilateral flow to  retrieve correctly the purposes