### PR TITLE
[1.9.8] serviceChainParams, ConsentId & serviceChainParams on Data Exchange & Consent routes clean up

### DIFF
--- a/docs/QUERY_PARAMS.md
+++ b/docs/QUERY_PARAMS.md
@@ -54,7 +54,7 @@ By adding the `providerParams` or `consumerParams` field at the exchange, the qu
 
 ## Applying Query Parameters to a Specific Resource
 
-If you want to apply query parameters to only one resource, you can specify them in the `resources` or `purposes` field:
+If you want to apply query parameters to only one resource, you can specify them in the `resources` (provider), `purposes` (consumer), `serviceChainParams` (during service chains) field:
 
 ```json
 {
@@ -77,6 +77,21 @@ If you want to apply query parameters to only one resource, you can specify them
       }
     ],
     "purposes": [
+      {
+        "resource": "https://a-ptx-catalog.com/v1/catalog/softwareresources/66d1889cee71f9f096bae98b",
+        "params": {
+          "query": [
+            {
+              "page": 2
+            },
+            {
+              "limit": 20
+            }
+          ]
+        }
+      }
+    ],
+    "serviceChainParams": [
       {
         "resource": "https://a-ptx-catalog.com/v1/catalog/softwareresources/66d1889cee71f9f096bae98b",
         "params": {

--- a/src/controllers/private/v1/consent.private.controller.ts
+++ b/src/controllers/private/v1/consent.private.controller.ts
@@ -45,6 +45,7 @@ export const getMyConsent = async (
 
 /**
  * Get consent by user JWT from consent manager
+ * @deprecated
  * @param req
  * @param res
  * @param next
@@ -239,6 +240,7 @@ export const getUserPrivacyNoticesByContract = async (
 
 /**
  * Get user privacy notices by id
+ * @deprecated
  */
 export const getUserPrivacyNoticeById = async (
     req: Request,
@@ -263,6 +265,7 @@ export const getUserPrivacyNoticeById = async (
 
 /**
  * Give consent
+ * @deprecated
  */
 export const giveConsent = async (
     req: Request,
@@ -288,6 +291,7 @@ export const giveConsent = async (
 
 /**
  * Trigger the data exchange by the user based on a consent
+ * @deprecated
  */
 export const consentDataExchange = async (
     req: Request,

--- a/src/controllers/public/v1/consent.public.controller.ts
+++ b/src/controllers/public/v1/consent.public.controller.ts
@@ -45,6 +45,7 @@ export const exportConsent = async (req: Request, res: Response) => {
                 purposeId: decryptedConsent.purposes[0].resource,
                 contract: decryptedConsent.contract,
                 status: 'PENDING',
+                consentId: decryptedConsent?._id,
                 createdAt: new Date(),
                 serviceChain: decryptedConsent.recipientThirdParties,
             });
@@ -56,6 +57,7 @@ export const exportConsent = async (req: Request, res: Response) => {
                 purposeId: decryptedConsent.purposes[0].resource,
                 contract: decryptedConsent.contract,
                 status: 'PENDING',
+                consentId: decryptedConsent?._id,
                 createdAt: new Date(),
             });
         }

--- a/src/controllers/public/v1/consumer.public.controller.ts
+++ b/src/controllers/public/v1/consumer.public.controller.ts
@@ -1,12 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { restfulResponse } from '../../../libs/api/RESTfulResponse';
 import { DataExchange, IDataExchange } from '../../../utils/types/dataExchange';
-import { postRepresentation } from '../../../libs/loaders/representationFetcher';
 import { handle } from '../../../libs/loaders/handler';
-import {
-    providerExport,
-    providerImport,
-} from '../../../libs/third-party/provider';
+import { providerExport } from '../../../libs/third-party/provider';
 import { Logger } from '../../../libs/loggers';
 import { DataExchangeStatusEnum } from '../../../utils/enums/dataExchangeStatusEnum';
 import {
@@ -41,6 +37,7 @@ export const consumerExchange = async (
             consumerParams,
             purposes,
             serviceChainId,
+            serviceChainParams,
         } = req.body;
 
         //Create a data Exchange
@@ -61,6 +58,7 @@ export const consumerExchange = async (
                 providerParams,
                 consumerParams,
                 serviceChainId,
+                serviceChainParams,
             });
 
             dataExchange = ecosystemDataExchange;
@@ -76,6 +74,7 @@ export const consumerExchange = async (
                 providerParams,
                 consumerParams,
                 serviceChainId,
+                serviceChainParams,
             });
 
             dataExchange = bilateralDataExchange;

--- a/src/routes/private/v1/consent.private.router.ts
+++ b/src/routes/private/v1/consent.private.router.ts
@@ -23,53 +23,6 @@ const r: Router = Router();
  *   description: Private routes for the consent
  */
 
-/**
- * @swagger
- * /private/consent/:
- *   post:
- *     summary: Give consent
- *     tags: [Consent]
- *     security:
- *       - jwt: []
- *     produces:
- *       - application/json
- *     parameters:
- *        - name: triggerDataExchange
- *          description: trigger the data exchange in the same time than the consent.
- *          in: query
- *          required: false
- *          type: boolean
- *     requestBody:
- *      content:
- *       application/json:
- *         schema:
- *           type: object
- *           properties:
- *             privacyNoticeId:
- *               required: true
- *               description: privacy notice id
- *               type: string
- *             userId:
- *               required: true
- *               description: user id from your system
- *               type: string
- *             email:
- *               description: email to reattach the user
- *               type: string
- *             serviceChainId:
- *               description: selected service chain
- *               type: string
- *             data:
- *               required: true
- *               description: selected data
- *               type: array
- *               items:
- *                  type: string
- *
- *     responses:
- *       '200':
- *         description: Successful response
- */
 r.post(
     '/',
     [
@@ -129,31 +82,6 @@ r.get('/exchanges/:as', auth, getAvailableExchanges);
  */
 r.get('/:userId/me', auth, getMyConsent);
 
-/**
- * @swagger
- * /private/consent/{userId}/{consentId}:
- *   delete:
- *     summary: revoke consent by id
- *     tags: [Consent]
- *     security:
- *       - jwt: []
- *     produces:
- *       - application/json
- *     parameters:
- *        - name: userId
- *          description: your internal id inside your app / database for the user.
- *          in: path
- *          required: true
- *          type: string
- *        - name: consentId
- *          description: consent id to revoke.
- *          in: path
- *          required: true
- *          type: string
- *     responses:
- *       '200':
- *         description: Successful response
- */
 r.delete('/:userId/:consentId', auth, revokeConsent);
 
 /**
@@ -183,63 +111,8 @@ r.delete('/:userId/:consentId', auth, revokeConsent);
  */
 r.get('/:userId/me/:id', auth, getMyConsentById);
 
-/**
- * @swagger
- * /private/consent/{userId}/privacy-notices/{privacyNoticeId}:
- *   get:
- *     summary: Get user privacy notices
- *     tags: [Consent]
- *     security:
- *       - jwt: []
- *     produces:
- *       - application/json
- *     parameters:
- *        - name: privacyNoticeId
- *          description: privacy notice id.
- *          in: path
- *          required: true
- *          type: string
- *        - name: userId
- *          description: internal id.
- *          in: path
- *          required: true
- *          type: string
- *     responses:
- *       '200':
- *         description: Successful response
- */
 r.get('/:userId/privacy-notices/:privacyNoticeId', getUserPrivacyNoticeById);
 
-/**
- * @swagger
- * /private/consent/{consentId}/data-exchange:
- *   post:
- *     summary: Trigger the data exchange by the user based on a consent
- *     tags: [Consent]
- *     security:
- *       - jwt: []
- *     produces:
- *       - application/json
- *     parameters:
- *        - name: consentId
- *          description: consent id.
- *          in: path
- *          required: true
- *          type: string
- *     requestBody:
- *      content:
- *       application/json:
- *         schema:
- *           type: object
- *           properties:
- *             userId:
- *               required: true
- *               description: user id from your system
- *               type: string
- *     responses:
- *       '200':
- *         description: Successful response
- */
 r.post('/:consentId/data-exchange', consentDataExchange);
 
 /**

--- a/src/routes/public/v1/consumer.public.router.ts
+++ b/src/routes/public/v1/consumer.public.router.ts
@@ -96,6 +96,19 @@ const r: Router = Router();
  *                           {"limit":10}
  *                       ]
  *               }
+ *             serviceChainParams:
+ *               description: Query params for the resource of the service chain
+ *               type: array
+ *               required: false
+ *               example: [{
+ *                   "resource": "https://catalog.api.com/v1/catalog/infrastructures/id",
+ *                   "params": {
+ *                       "query": [
+ *                           {"page":0},
+ *                           {"limit":10}
+ *                       ]
+ *                   }
+ *               }]
  *       '200':
  *         description: Successful response
  */
@@ -111,6 +124,7 @@ r.post(
         body('consumerParams').isArray().optional(),
         body('purposes').isArray().optional(),
         body('serviceChainId').isString().optional(),
+        body('serviceChainParams').isArray().optional(),
     ],
     consumerExchange
 );

--- a/src/routes/public/v1/dataExchange.public.router.ts
+++ b/src/routes/public/v1/dataExchange.public.router.ts
@@ -5,7 +5,8 @@ import {
     getDataExchanges,
     updateDataExchange,
     getDataExchangeById,
-    createDataExchange, updateDataExchangeDataProcessing,
+    createDataExchange,
+    updateDataExchangeDataProcessing,
 } from '../../../controllers/public/v1/dataExchange.public.controller';
 const r: Router = Router();
 
@@ -46,18 +47,6 @@ const r: Router = Router();
  *           description: timestamp.
  */
 
-// /**
-//  * @swagger
-//  * /dataexchanges:
-//  *   post:
-//  *     summary: Create a data Exchange
-//  *     tags: [Data-Exchange]
-//  *     produces:
-//  *       - application/json
-//  *     responses:
-//  *       '200':
-//  *         description: Successful response
-//  */
 r.post('/', createDataExchange);
 
 /**

--- a/src/routes/public/v1/exchange.public.router.ts
+++ b/src/routes/public/v1/exchange.public.router.ts
@@ -83,6 +83,19 @@ const r: Router = Router();
  *                           {"limit":10}
  *                       ]
  *               }
+ *             serviceChainParams:
+ *               description: Query params for the resource of the service chain
+ *               type: array
+ *               required: false
+ *               example: [{
+ *                   "resource": "https://catalog.api.com/v1/catalog/infrastructures/id",
+ *                   "params": {
+ *                       "query": [
+ *                           {"page":0},
+ *                           {"limit":10}
+ *                       ]
+ *                   }
+ *               }]
  *       '200':
  *         description: Successful response
  */
@@ -96,6 +109,9 @@ r.post(
         body('resources').isArray().optional(),
         body('providerParams').isArray().optional(),
         body('serviceChainId').isString().optional(),
+        body('consumerParams').isArray().optional(),
+        body('purposes').isArray().optional(),
+        body('serviceChainParams').isArray().optional(),
     ],
     consumerExchange
 );

--- a/src/services/public/v1/consumer.public.service.ts
+++ b/src/services/public/v1/consumer.public.service.ts
@@ -24,6 +24,7 @@ export const triggerBilateralFlow = async (props: {
     providerParams?: IParams;
     serviceChainId?: string;
     consumerParams?: IParams;
+    serviceChainParams?: IParams;
     dataProcessingId?: string;
 }) => {
     const {
@@ -32,6 +33,7 @@ export const triggerBilateralFlow = async (props: {
         providerParams,
         consumerParams,
         serviceChainId,
+        serviceChainParams,
     } = props;
 
     const contract = props.contract;
@@ -130,6 +132,7 @@ export const triggerEcosystemFlow = async (props: {
     providerParams?: IParams;
     serviceChainId?: string;
     consumerParams?: IParams;
+    serviceChainParams?: IParams;
 }) => {
     const {
         contract,
@@ -138,6 +141,7 @@ export const triggerEcosystemFlow = async (props: {
         serviceChainId,
         purposes,
         consumerParams,
+        serviceChainParams,
     } = props;
 
     let { resourceId, purposeId } = props;
@@ -270,7 +274,9 @@ export const triggerEcosystemFlow = async (props: {
             purposeId: purposeId,
             contract: contract,
             status: 'PENDING',
-            providerParams: providerParams,
+            providerParams: providerParams ?? [],
+            consumerParams: consumerParams ?? [],
+            serviceChainParams: serviceChainParams ?? [],
             createdAt: new Date(),
             serviceChain: serviceChain ?? [],
         });
@@ -289,6 +295,7 @@ export const triggerEcosystemFlow = async (props: {
             status: 'PENDING',
             providerParams: providerParams ?? [],
             consumerParams: consumerParams ?? [],
+            serviceChainParams: serviceChainParams ?? [],
             createdAt: new Date(),
             serviceChain: serviceChain ?? [],
         });
@@ -307,6 +314,7 @@ export const triggerEcosystemFlow = async (props: {
             status: 'PENDING',
             providerParams: providerParams ?? [],
             consumerParams: consumerParams ?? [],
+            serviceChainParams: serviceChainParams ?? [],
             createdAt: new Date(),
             serviceChain: serviceChain ?? [],
         });

--- a/src/utils/isJsonString.ts
+++ b/src/utils/isJsonString.ts
@@ -1,0 +1,8 @@
+export const isJsonString = (string: string) => {
+    try {
+        JSON.parse(string);
+        return true;
+    } catch (e) {
+        return false;
+    }
+};

--- a/src/utils/paramsMapper.ts
+++ b/src/utils/paramsMapper.ts
@@ -18,7 +18,11 @@ export const paramsMapper = async (params: {
     const { representationQueryParams, dataExchange, resource, type } = params;
     let { url } = params;
     const isAlreadyParamInUrl = params.url.includes('?');
-    const subType = type === 'providerParams' ? 'resources' : 'purposes';
+    const subTypes: ['resources', 'purposes', 'serviceChainParams'] = [
+        'resources',
+        'purposes',
+        'serviceChainParams',
+    ];
 
     //if providerParams exists use it
     if (dataExchange[type].query && dataExchange[type]?.query?.length > 0) {
@@ -30,9 +34,14 @@ export const paramsMapper = async (params: {
     }
     //else find resource params
     else {
-        const resourceParams = dataExchange[subType].find(
-            (element) => element?.resource === resource
-        );
+        let resourceParams;
+        for (const subType of subTypes) {
+            resourceParams = dataExchange[subType].find(
+                (element: { resource: string }) =>
+                    element?.resource === resource
+            );
+        }
+
         if (!resourceParams || !resourceParams.params) {
             return { url };
         }

--- a/src/utils/types/dataExchange.ts
+++ b/src/utils/types/dataExchange.ts
@@ -45,12 +45,14 @@ interface IDataExchange {
     consumerDataExchange?: string;
     providerDataExchange?: string;
     status: string;
+    consentId?: string;
     createdAt: string;
     updatedAt?: string;
     payload?: string;
     providerParams?: IParams;
-    serviceChain?: ContractServiceChain;
     consumerParams?: IParams;
+    serviceChain?: ContractServiceChain;
+    serviceChainParams?: [IData];
 
     // Define method signatures
     createDataExchangeToOtherParticipant(
@@ -65,9 +67,12 @@ interface IDataExchange {
     completeServiceChain(serviceOffering: string): Promise<void>;
 }
 
-const paramsSchema = new Schema({
-    query: [{ type: Schema.Types.Mixed, required: true }],
-});
+const paramsSchema = new Schema(
+    {
+        query: [{ type: Schema.Types.Mixed, required: true }],
+    },
+    { _id: false }
+);
 
 export type DataExchangeResult = {
     exchange: IDataExchange;
@@ -82,11 +87,16 @@ interface IDataExchangeMethods {
     updateStatus(status: string, payload?: any): Promise<IDataExchangeModel>;
 }
 
-const dataSchema = new Schema({
-    serviceOffering: String,
-    resource: String,
-    params: paramsSchema,
-});
+const dataSchema = new Schema(
+    {
+        serviceOffering: String,
+        resource: String,
+        params: paramsSchema,
+    },
+    {
+        _id: false,
+    }
+);
 
 const schema = new Schema({
     resources: [dataSchema],
@@ -101,12 +111,14 @@ const schema = new Schema({
     createdAt: Date,
     updatedAt: Date,
     payload: String,
+    consentId: String,
     providerParams: {
         query: [{ type: Schema.Types.Mixed, required: true }],
     },
     consumerParams: {
         query: [{ type: Schema.Types.Mixed, required: true }],
     },
+    serviceChainParams: [dataSchema],
     serviceChain: {
         catalogId: String,
         services: [
@@ -138,8 +150,10 @@ schema.methods.createDataExchangeToOtherParticipant = async function (
             purposeId: this.purposeId,
             contract: this.contract,
             status: this.status,
+            consentId: this.consentId,
             providerParams: this.providerParams,
             consumerParams: this.consumerParams,
+            serviceChainParams: this.serviceChainParams,
             consumerDataExchange: this._id,
             serviceChain: this.serviceChain,
         };
@@ -151,8 +165,10 @@ schema.methods.createDataExchangeToOtherParticipant = async function (
             purposeId: this.purposeId,
             contract: this.contract,
             status: this.status,
+            consentId: this.consentId,
             providerParams: this.providerParams,
             consumerParams: this.consumerParams,
+            serviceChainParams: this.serviceChainParams,
             providerDataExchange: this._id,
             serviceChain: this.serviceChain,
         };
@@ -219,12 +235,14 @@ schema.methods.syncWithInfrastructure = async function (
             providerParams: this.providerParams,
             serviceChain: this.serviceChain,
             consumerParams: this.consumerParams,
+            serviceChainParams: this.serviceChainParams,
             resources: this.resources,
             purposes: this.purposes,
             purposeId: this.purposeId,
             contract: this.contract,
             consumerEndpoint: this.consumerEndpoint,
             status: this.status,
+            consentId: this.consentId,
             consumerDataExchange: this.consumerDataExchange,
             providerDataExchange: this.providerDataExchange,
             providerEndpoint: this.providerEndpoint,

--- a/src/utils/verifyInfrastructureInContract.ts
+++ b/src/utils/verifyInfrastructureInContract.ts
@@ -9,7 +9,7 @@ export const verifyInfrastructureInContract = (props: {
     //verify that the contract contain this chain and the chain contain the service
     const chain = contract.serviceChains.find(
         (element) =>
-            element.catalogId === chainId && element.status === 'active'
+            element.catalogId === chainId || element.serviceChainId === chainId
     );
     if (!chain) {
         throw Error(


### PR DESCRIPTION
## ✨ Feat
* added consentId and serviceChainParams on the Data Exchange mode
* added serviceChainParams in exchange payload to apply params during service chain
* added docs for serviceChainParams

## ♻️ Refactor
* deleted consent routes from swagger docs and tagged it deprecated
* updated logic in paramsMapper.ts to iterate to resources, purposes and serviceChainParams to find the resource
* updated verifyInfrastructureInContract.ts to be up to date with contract-manager

## 🧹 Chore

* clean commented code




