### PR TITLE
Fix : reproducible Docker builds (pnpm 10 + Node 22) and JWT crash on invalid signature

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,10 +1,10 @@
 # Use the official Node.js image as base image
-FROM node:lts
+FROM node:22
 ARG ENV
-ENV ENV $ENV
+ENV ENV=$ENV
 
 # Install pnpm globally
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10.34.1
 
 # Create app directory
 RUN mkdir -p /usr/src/app
@@ -24,7 +24,7 @@ RUN mkdir -p /src/logs
 RUN mkdir -p /src/keys
 
 # Install app dependencies
-RUN CI=true pnpm i
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Expose the port on which the app will run
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
     "description": "Prometheus-X Data Space Connector",
     "main": "src/index.ts",
     "engines": {
-        "node": ">=18"
+        "node": ">=22"
     },
+    "packageManager": "pnpm@10.34.1",
     "scripts": {
         "dev": "nodemon -L --development",
         "provider": "nodemon -L --provider",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1078,7 +1078,7 @@ packages:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
   data-processing-chain-protocol@https://codeload.github.com/Prometheus-X-association/data-processing-chain-protocol/tar.gz/d497cd2d56bebf58b57188a99d307160ecfc6b8c:
-    resolution: {tarball: https://codeload.github.com/Prometheus-X-association/data-processing-chain-protocol/tar.gz/d497cd2d56bebf58b57188a99d307160ecfc6b8c}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/Prometheus-X-association/data-processing-chain-protocol/tar.gz/d497cd2d56bebf58b57188a99d307160ecfc6b8c}
     version: 0.0.0
 
   data-view-buffer@1.0.1:
@@ -1944,7 +1944,7 @@ packages:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
   json-odrl-manager@https://codeload.github.com/Prometheus-X-association/odrl-manager/tar.gz/f5a1070514cab107b776f4f866357521720174f1:
-    resolution: {tarball: https://codeload.github.com/Prometheus-X-association/odrl-manager/tar.gz/f5a1070514cab107b776f4f866357521720174f1}
+    resolution: {gitHosted: true, integrity: sha512-T2KXoLsrP8OqQlI14z3RoF8b0kcmvTtGJ6oYKXw87m1JFKtbFn0I9JEH/jQJdOQNHrnhjNs41RzyZXFJa28xbw==, tarball: https://codeload.github.com/Prometheus-X-association/odrl-manager/tar.gz/f5a1070514cab107b776f4f866357521720174f1}
     version: 2.0.0-alpha.5
     engines: {node: '>=14.0.0'}
 
@@ -3212,7 +3212,7 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.1/xlsx-0.20.1.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.1/xlsx-0.20.1.tgz}
+    resolution: {integrity: sha512-hA7SYmn/H3cJ1VGi7kmSKxbEXCEn5UVJlwYFSFXhLe54wPUvW+80TmR5l+TZh4nJCw8G/e0SuZUfvqlTIh40hw==, tarball: https://cdn.sheetjs.com/xlsx-0.20.1/xlsx-0.20.1.tgz}
     version: 0.20.1
     engines: {node: '>=0.8'}
     hasBin: true

--- a/src/libs/jwt/index.ts
+++ b/src/libs/jwt/index.ts
@@ -40,8 +40,12 @@ export const regenerateToken = async (refreshToken: string) => {
  * Verifies the authorization bearer token
  * @param token authorization bearer token
  */
-export const verifyToken = async (token: string): Promise<any | string> => {
+export const verifyToken = async (token: string): Promise<any | null> => {
+    try {
         return jwt.verify(token, await getSecretKey());
+    } catch (error) {
+        return null;
+    }
 };
 
 /**

--- a/src/routes/middlewares/auth.middleware.ts
+++ b/src/routes/middlewares/auth.middleware.ts
@@ -14,7 +14,11 @@ export const auth = async (req: Request, res: Response, next: NextFunction) => {
             .json({ message: 'You need to be authenticated' });
     }
     const token = req.header('Authorization').slice(7);
-    const jwt = await verifyToken(token);
-    if (!jwt) return res.status(401).json('You need to be Authenticated');
-    else next();
+    try {
+        const jwt = await verifyToken(token);
+        if (!jwt) return res.status(401).json('You need to be Authenticated');
+        else next();
+    } catch (error) {
+        return res.status(401).json('You need to be Authenticated');
+    }
 };


### PR DESCRIPTION
## Summary

Two independent fixes targeting deployment reliability and runtime stability of the dataspace connector.

---

## Fix 1 — Reproducible Docker builds

### Problem
`docker compose build` was failing with: ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE

The Dockerfile used `FROM node:lts` and `npm install -g pnpm` (both unpinned). Docker was pulling pnpm 10.x, but the lockfile had been generated with pnpm 9.x. pnpm 10 refuses to install from a v9 lockfile in frozen mode, which is enabled by default in CI.

### Changes
- `docker/app/Dockerfile`: pin to `node:22` (active LTS, EOL April 2027) and `pnpm@10.34.1`; replace `CI=true pnpm i` with `pnpm install --frozen-lockfile --ignore-scripts`; fix legacy `ENV key value` format
- `package.json`: add `"packageManager": "pnpm@10.34.1"` (corepack enforcement); tighten `engines` to `>=22`
- `pnpm-lock.yaml`: migrate from pnpm 9.x format to pnpm 10.x native format; inject `sha512` integrity hash for the `xlsx` CDN tarball (required by pnpm 10 supply-chain enforcement)

### Why `--ignore-scripts`
The `postinstall` script runs `git init && git config core.hooksPath` — a developer-only hook that is pointless and wasteful inside a Docker build layer.

---

## Fix 2 — JWT invalid signature crashes server

### Problem
Reported in production on v1.10.1: sending a token with an invalid signature caused the server process to crash instead of returning `401`.

`jwt.verify()` throws synchronously (`JsonWebTokenError: invalid signature`). Without a `try/catch`, this propagated as an unhandled rejection from the `await` in the auth middleware, killing the Node process.

### Changes
- `src/libs/jwt/index.ts`: wrap `jwt.verify()` in `try/catch` inside `verifyToken()`; return `null` on any JWT error (`JsonWebTokenError`, `TokenExpiredError`, `NotBeforeError`)
- `src/routes/middlewares/auth.middleware.ts`: add `try/catch` around the `verifyToken()` call as a defensive fallback

### Result
Invalid-signature tokens now return `401`. The server stays alive and continues serving subsequent requests.

---

## Test coverage
- Docker build verified locally with `--no-cache`; `pnpm install --frozen-lockfile` passes in < 1s
- JWT fix: `verifyToken()` returns `null` for invalid/expired/malformed tokens; `auth` middleware returns `401` in all error cases without crashing the process