### PR TITLE
[1.11.0] - Direct Response Visualization

### DIFF
--- a/docs/DIRECT_RESPONSE_VISUALIZATION.md
+++ b/docs/DIRECT_RESPONSE_VISUALIZATION.md
@@ -15,6 +15,8 @@ This is particularly useful for:
 - **Injecting custom data** through a service chain without requiring a live provider.
 - **Direct integration** of the PDC data exchange requests
 
+> ⚠️ **Limitation — Consent flow not supported**: exchanges that involve a consent-based flow are **not compatible** with `directResponseVisualization`. The long-polling mechanism cannot accommodate the asynchronous, user-driven nature of the consent validation step. Using `directResponseVisualization: true` in a consent-based exchange will result in a timeout.
+
 ---
 
 ## How It Works
@@ -438,6 +440,7 @@ This feature was introduced in connector version **1.11.0**. The table below sum
 - **The only blocking case** is when a ≥ 1.11.0 consumer sends the `data` field **without** `resourceId` to a provider on a lower version. Since the older provider cannot handle a request missing a resource reference, the exchange will fail. To stay safe when the provider version is unknown or older, always include `resourceId` alongside `data`.
 - **When a ≥ 1.11.0 consumer targets a < 1.11.0 provider** and uses `directResponseVisualization: true` (without `data`), the exchange proceeds normally but the feature is non-functional — the timeout elapses and the response returns `directResponseVisualization: null`.
 - **A consumer on a version lower than 1.11.0** does not expose the `directResponseVisualization` or `data` fields. Any client sending those fields to such a consumer will receive a standard exchange response — the exchange itself is unaffected.
+- **Consent-based exchanges are not supported.** The consent flow relies on an asynchronous, user-driven validation step that is incompatible with the long-polling mechanism. Do not use `directResponseVisualization: true` in exchanges that require consent validation.
 
 ---
 
@@ -461,6 +464,7 @@ This feature was introduced in connector version **1.11.0**. The table below sum
 - **docs**: Added *Backward Compatibility* section documenting version interoperability rules between connector versions.
 - **docs**: Clarified that if either the consumer or the provider is on a version lower than 1.11.0, `directResponseVisualization` and `data` features are non-functional but do not block exchanges.
 - **docs**: Documented the only breaking case: a ≥ 1.11.0 consumer sending `data` without `resourceId` to a < 1.11.0 provider will cause the exchange to fail.
+- **docs**: Documented that consent-based exchanges are not supported by the `directResponseVisualization` feature.
 - **feat**: Added `pdcVersion` field to the `DataExchange` document to store the connector version at exchange creation time, enabling backward compatibility checks.
 
 ### 2026-07-06

--- a/docs/DIRECT_RESPONSE_VISUALIZATION.md
+++ b/docs/DIRECT_RESPONSE_VISUALIZATION.md
@@ -1,0 +1,454 @@
+# Direct Response Visualization
+
+## Description
+
+The **Direct Response Visualization** feature allows a participant to trigger a data exchange and **synchronously receive the exchanged data** in the HTTP response of the `/consumer/exchange` endpoint.
+
+By default, a data exchange is fire-and-forget: the consumer endpoint returns immediately after kicking off the exchange, and the data is imported asynchronously into the consumer's software representation. With Direct Response Visualization enabled, the request is kept open (long-polling) until the provider has exported and the consumer has imported the data, at which point the raw imported payload is returned directly to the caller.
+
+The optional **`data`** field allows the caller to **inject a data payload directly** into the exchange, bypassing the provider export step entirely. When `data` is supplied the connector skips the provider-side fetch and uses the provided array as the source data, which is then passed through the service chain (or directly to the consumer software representation).
+
+This is particularly useful for:
+- **Live previews** of a dataset before committing to a full integration.
+- **Debugging and testing** data pipelines end-to-end.
+- **API-driven workflows** where the caller needs the data synchronously.
+- **Injecting custom data** through a service chain without requiring a live provider.
+- **Direct integration**  of the PDC data exchange requests
+
+---
+
+## How It Works
+
+### 1. The participant triggers the exchange with `directResponseVisualization: true`
+
+The simplest form — standard bilateral exchange:
+
+```http
+POST /consumer/exchange
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "contract": "https://contract.com/contracts/<id>",
+  "resourceId": "https://catalog.api.com/v1/catalog/serviceofferings/<id>",
+  "purposeId":  "https://catalog.api.com/v1/catalog/serviceofferings/<id>",
+  "directResponseVisualization": true
+}
+```
+
+When the **`data`** field is provided, `resourceId` is **no longer required** because the payload itself replaces the provider export:
+
+```http
+POST /consumer/exchange
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "contract": "https://contract.com/contracts/<id>",
+  "purposeId": "https://catalog.api.com/v1/catalog/serviceofferings/<id>",
+  "directResponseVisualization": true,
+  "data": [ { "_id": "...", "email": "john@doe.com", "..." : "..." } ]
+}
+```
+
+### 2. A unique callback ID and promise are created
+
+The controller generates a unique `directResponseVisualizationId` (MongoDB `ObjectId`) and registers a pending `Promise` in an **in-memory map** (`pendingDirectResponseVisualizations`).
+
+```
+pendingDirectResponseVisualizations[directResponseVisualizationId] = { resolve, timer }
+```
+
+A timeout (default **30 seconds**, configurable via the `EXCHANGE_TIMEOUT` environment variable) is started. If the callback is not received within this window, the promise is rejected and an error message is returned.
+
+### 3. The exchange is initiated with the callback metadata
+
+The `directResponseVisualizationId` is forwarded to either `triggerBilateralFlow` or `triggerEcosystemFlow`. Both flows store two extra fields on the created `DataExchange` document:
+
+| Field                           | Value                                                                                        |
+|---------------------------------|----------------------------------------------------------------------------------------------|
+| `directResponseVisualizationId` | The unique ID generated in step 2                                                            |
+| `callbackUrl`                   | `{consumerEndpoint}/callbacks/direct-response-visualization/{directResponseVisualizationId}` |
+| `data`                          | `true` when a data payload was injected by the caller (field stored as a boolean flag)       |
+
+### 4. The provider exports and the consumer imports the data
+
+- **Without `data`**: The standard exchange flow proceeds normally (provider export → consumer import).
+- **With `data`**: The provider export step is skipped. The injected payload is used directly as the source data and forwarded through the service chain or straight to the consumer software representation.
+
+### 5. The consumer service posts data back to the callback URL
+
+At the end of `consumerImportService`, after a successful import, the consumer connector calls:
+
+```http
+POST {consumerEndpoint}/callbacks/direct-response-visualization/{directResponseVisualizationId}
+Content-Type: application/json
+
+<imported data payload>
+```
+
+### 6. The callback route resolves the pending promise
+
+`POST /callbacks/direct-response-visualization/:directResponseVisualizationId` looks up the `directResponseVisualizationId` in `pendingDirectResponseVisualizations`, cancels the timeout timer, removes the entry from the map, and resolves the promise with the received body.
+
+### 7. The original request returns the data
+
+The `/consumer/exchange` response now includes the `directResponseVisualization` field populated with the imported data:
+
+```json
+{
+  "success": true,
+  "dataExchange": { "..." : "..." },
+  "directResponseVisualization": { "..." : "..." }
+}
+```
+
+---
+
+## Flow Diagram
+
+### Standard flow (no `data` field)
+
+```
+Caller
+  │
+  │  POST /consumer/exchange  { directResponseVisualization: true }
+  ▼
+Consumer Connector
+  ├─ generates directResponseVisualizationId
+  ├─ registers pending Promise in pendingDirectResponseVisualizations map
+  ├─ creates DataExchange (stores directResponseVisualizationId + callbackUrl)
+  ├─ triggers provider export
+  │
+  │  (awaits callbackPromise — request is held open)
+  │
+  ▼
+Provider Connector
+  └─ exports data → POST /consumer/import
+
+Consumer Connector
+  └─ consumerImportService
+       └─ imports data into software representation
+       └─ POST {callbackUrl}  ← sends imported data back
+
+Consumer Connector  /callbacks/direct-response-visualization/:directResponseVisualizationId
+  └─ resolves pending Promise with imported payload
+  │
+  ▼
+Caller  ← receives { success, dataExchange, directResponseVisualization: <data> }
+```
+
+### Injected data flow (`data` field provided)
+
+```
+Caller
+  │
+  │  POST /consumer/exchange  { directResponseVisualization: true, data: [...] }
+  ▼
+Consumer Connector
+  ├─ generates directResponseVisualizationId
+  ├─ registers pending Promise in pendingDirectResponseVisualizations map
+  ├─ creates DataExchange (stores directResponseVisualizationId + callbackUrl + data: true)
+  ├─ skips provider export — uses injected data payload directly
+  │
+  │  (awaits callbackPromise — request is held open)
+  │
+  ▼
+Consumer Connector
+  └─ consumerImportService (processes injected data through service chain if applicable)
+       └─ imports result into software representation
+       └─ POST {callbackUrl}  ← sends imported data back
+
+Consumer Connector  /callbacks/direct-response-visualization/:directResponseVisualizationId
+  └─ resolves pending Promise with imported payload
+  │
+  ▼
+Caller  ← receives { success, dataExchange, directResponseVisualization: <data> }
+```
+
+---
+
+## Usage Examples
+
+### 1. Basic bilateral exchange
+
+```json
+{
+    "contract": "http://host.docker.internal:8888/contracts/6a0efda83d981b2bab2dadd5",
+    "purposeId": "http://host.docker.internal:4040/v1/catalog/serviceofferings/66d18b79ee71f9f096baecb0",
+    "resourceId": "http://host.docker.internal:4040/v1/catalog/serviceofferings/66d187f4ee71f9f096bae8ca",
+    "directResponseVisualization": true
+}
+```
+
+### 2. Basic exchange with injected data (no `resourceId` required)
+
+When `data` is provided, the provider export is bypassed and `resourceId` can be omitted:
+
+```json
+{
+    "contract": "http://host.docker.internal:8888/contracts/6a0efda83d981b2bab2dadd5",
+    "purposeId": "http://host.docker.internal:4040/v1/catalog/serviceofferings/66d18b79ee71f9f096baecb0",
+    "directResponseVisualization": true,
+    "data": [
+        {
+            "_id": "660ffe57aecb6ea62e307901",
+            "__v": 0,
+            "createdAt": "2024-04-11T14:24:00.529Z",
+            "email": "john+1@doe.com",
+            "oauth": {
+                "google": {
+                    "id": "",
+                    "email": "",
+                    "verified_email": false,
+                    "name": "",
+                    "given_name": "",
+                    "family_name": "",
+                    "picture": "",
+                    "locale": ""
+                }
+            },
+            "schema_version": "1",
+            "updatedAt": "2024-05-30T09:34:11.196Z",
+            "verified_email": true
+        }
+    ]
+}
+```
+
+### 3. Service chain exchange
+
+```json
+{
+    "contract": "http://host.docker.internal:8888/contracts/6a0efda83d981b2bab2dadd5",
+    "serviceChainId": "6a2805a3b1f55f757e783e9e",
+    "directResponseVisualization": true
+}
+```
+
+> ℹ️ A service chain can work **with or without a data offering as the first node**.
+
+### 4. Service chain exchange with injected data
+
+When `data` is provided alongside a `serviceChainId`, the injected payload is used as the source even if the first node of the chain is a data offering. The chain is executed with the provided data as input:
+
+```json
+{
+    "contract": "http://host.docker.internal:8888/contracts/6a0efda83d981b2bab2dadd5",
+    "serviceChainId": "6a2805a3b1f55f757e783e9e",
+    "directResponseVisualization": true,
+    "data": [
+        {
+            "_id": "660ffe57aecb6ea62e307901",
+            "__v": 0,
+            "createdAt": "2024-04-11T14:24:00.529Z",
+            "email": "john+1@doe.com",
+            "oauth": {
+                "google": {
+                    "id": "",
+                    "email": "",
+                    "verified_email": false,
+                    "name": "",
+                    "given_name": "",
+                    "family_name": "",
+                    "picture": "",
+                    "locale": ""
+                }
+            },
+            "schema_version": "1",
+            "updatedAt": "2024-05-30T09:34:11.196Z",
+            "verified_email": true
+        }
+    ]
+}
+```
+
+---
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `EXCHANGE_TIMEOUT` | `30` | Maximum number of **seconds** to wait for the data callback before returning a timeout error. |
+
+---
+
+## API Reference
+
+### `POST /consumer/exchange`
+
+Existing endpoint — extended with the optional `directResponseVisualization` and `data` fields.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `contract` | `string` | ✅ | Contract self-description URL |
+| `resourceId` | `string` | ❌ | Provider service offering URI. **Not required when `data` is provided.** |
+| `purposeId` | `string` | ❌ | Consumer service offering URI (ecosystem) |
+| `resources` | `array` | ❌ | Array of data resource URIs |
+| `purposes` | `array` | ❌ | Array of software resource URIs |
+| `providerParams` | `object` | ❌ | Query params forwarded to the provider |
+| `consumerParams` | `object` | ❌ | Query params forwarded to the consumer |
+| `serviceChainId` | `string` | ❌ | ID of the service chain in the contract |
+| `serviceChainParams` | `array` | ❌ | Params for service chain resources |
+| **`directResponseVisualization`** | `boolean` | ❌ | When `true`, the response waits and returns the exchanged data |
+| **`data`** | `array` | ❌ | Array of data objects to inject directly into the exchange, bypassing the provider export step. Compatible with both bilateral and service chain flows. |
+
+**Response (200) — with service chain**
+```json
+{
+    "timestamp": 1783342073905,
+    "code": 200,
+    "content": {
+        "success": true,
+        "dataExchange": {
+            "providerParams": { "query": [] },
+            "consumerParams": { "query": [] },
+            "serviceChain": {
+                "catalogId": "6a2805a3b1f55f757e783e9e",
+                "services": [
+                    {
+                        "participant": "http://host.docker.internal:4040/v1/catalog/participants/66d18724ee71f9f096bae810",
+                        "service": "http://host.docker.internal:4040/v1/catalog/serviceofferings/66d187f4ee71f9f096bae8ca",
+                        "params": "",
+                        "pre": [],
+                        "completed": true,
+                        "_id": "6a4ba3f920ded79942357dda"
+                    },
+                    {
+                        "participant": "http://host.docker.internal:4040/v1/catalog/participants/66d18a1dee71f9f096baec07",
+                        "service": "http://host.docker.internal:4040/v1/catalog/infrastructureservices/67f669b57b3045a9bb30e240",
+                        "params": "",
+                        "pre": [],
+                        "completed": true,
+                        "_id": "6a4ba3f920ded79942357ddb"
+                    },
+                    {
+                        "participant": "http://host.docker.internal:4040/v1/catalog/participants/66d18a1dee71f9f096baec08",
+                        "service": "http://host.docker.internal:4040/v1/catalog/serviceofferings/66d18b79ee71f9f096baecb0",
+                        "params": "",
+                        "pre": [],
+                        "completed": true,
+                        "_id": "6a4ba3f920ded79942357ddc"
+                    }
+                ]
+            },
+            "_id": "6a4ba3f920ded79942357dd9",
+            "resources": [],
+            "purposes": [
+                {
+                    "serviceOffering": "http://host.docker.internal:4040/v1/catalog/serviceofferings/66d18b79ee71f9f096baecb0",
+                    "resource": "http://host.docker.internal:4040/v1/catalog/softwareresources/66d18bf6ee71f9f096baed58"
+                }
+            ],
+            "purposeId": "http://host.docker.internal:4040/v1/catalog/serviceofferings/66d18b79ee71f9f096baecb0",
+            "contract": "http://host.docker.internal:8888/contracts/6a0efda83d981b2bab2dadd5",
+            "consumerEndpoint": "http://host.docker.internal:3334/",
+            "status": "IMPORT_SUCCESS",
+            "createdAt": "2026-07-06T12:47:53.637Z",
+            "serviceChainParams": [],
+            "directResponseVisualizationId": "6a4ba3f920ded79942357dd3",
+            "callbackUrl": "http://host.docker.internal:3333/callbacks/direct-response-visualization/6a4ba3f920ded79942357dd3",
+            "data": true,
+            "__v": 1,
+            "consumerDataExchange": "6a4ba3f9eb5c8c65fa985d0a"
+        },
+        "directResponseVisualization": {
+            "message": "Data received and stored.",
+            "dataReceived": {
+                "data": [
+                    {
+                        "_id": "660ffe57aecb6ea62e307901",
+                        "__v": 0,
+                        "createdAt": "2024-04-11T14:24:00.529Z",
+                        "email": "john+1@doe.com",
+                        "oauth": {
+                            "google": {
+                                "id": "",
+                                "email": "",
+                                "verified_email": false,
+                                "name": "",
+                                "given_name": "",
+                                "family_name": "",
+                                "picture": "",
+                                "locale": ""
+                            }
+                        },
+                        "schema_version": "1",
+                        "updatedAt": "2024-05-30T09:34:11.196Z",
+                        "verified_email": true,
+                        "score": 94
+                    }
+                ],
+                "contract": "http://host.docker.internal:8888/contracts/6a0efda83d981b2bab2dadd5",
+                "params": ""
+            },
+            "storedId": "6a4ba3f9cbe3a8ec81bb6eb7"
+        }
+    }
+}
+```
+
+> ℹ️ When `data` was injected in the request, the `dataExchange.data` field is set to `true` (boolean flag) in the stored document.
+
+**Response — timeout (200)**
+```json
+{
+  "success": false,
+  "dataExchange": { "...": "..." },
+  "message": "30 sec Timeout reached.",
+  "directResponseVisualization": null
+}
+```
+
+---
+
+### `POST /callbacks/direct-response-visualization/:directResponseVisualizationId`
+
+Internal callback endpoint used by the consumer import service to resolve a pending direct response visualization.
+
+> ⚠️ This endpoint is **not meant to be called by external clients**. It is called automatically by `consumerImportService` at the end of the import phase.
+
+| Parameter | In | Type | Required | Description |
+|---|---|---|---|---|
+| `directResponseVisualizationId` | path | `string` | ✅ | The unique ID of the pending direct response visualization |
+| *(body)* | body | `object` | ✅ | The imported data payload to return to the caller |
+
+**Responses**
+
+| Status | Description |
+|---|---|
+| `200` | Data preview successfully resolved |
+| `404` | No pending direct response visualization found for the given ID (already resolved, timed out, or unknown) |
+
+---
+
+## Files Changed
+
+| File                                                      | Change                                                                                                                                                                                                                                                                                                             |
+|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `src/routes/public/v1/consumer.public.router.ts`          | Added `body('directResponseVisualization').isBoolean().optional()` and `body('data').isArray().optional()` validators to `/consumer/exchange`                                                                                                                                                                      |
+| `src/controllers/public/v1/consumer.public.controller.ts` | Added `directResponseVisualization` / `directResponseVisualizationId` / `callbackPromise` / `data` logic; returns `directResponseVisualization` payload in response                                                                                                                                                |
+| `src/services/public/v1/consumer.public.service.ts`       | `triggerBilateralFlow` and `triggerEcosystemFlow` now accept and store `directResponseVisualizationId`, `callbackUrl`, and `data` (boolean flag) on the `DataExchange` document; when `data` is provided the provider export is skipped; `consumerImportService` posts the imported data to `callbackUrl` when set |
+| `src/libs/loaders/pendingDirectResponseVisualization.ts`  | New file — exports the `pendingDirectResponseVisualizations` in-memory `Map` shared between the controller and the callback route                                                                                                                                                                                  |
+| `src/routes/public/v1/callback.public.router.ts`          | New route `POST /callbacks/direct-response-visualization/:directResponseVisualizationId` to resolve pending previews                                                                                                                                                                                               |
+
+---
+
+## Changelog
+
+### 2026-07-06
+
+- **feat**: Added `data` array field to `POST /consumer/exchange` request body, allowing the caller to inject a data payload directly into the exchange.
+- **feat**: When `data` is provided, the provider export step is bypassed — `resourceId` is no longer required.
+- **feat**: `data` field is compatible with service chain exchanges: the injected payload is used as the chain's input even when the first node is a data offering.
+- **feat**: `dataExchange.data` is stored as `true` (boolean flag) on the `DataExchange` document when a payload was injected.
+
+### 2026-07-03
+
+- **feat**: Renamed `dataPreview` to `directResponseVisualization` boolean field to `POST /consumer/exchange` request body.
+- **feat**: Created `pendingDirectResponseVisualizations` in-memory map to hold unresolved preview promises.
+- **feat**: `triggerBilateralFlow` and `triggerEcosystemFlow` now persist `directResponseVisualizationId` and `callbackUrl` on the `DataExchange` document.
+- **feat**: `consumerImportService` automatically POSTs the imported payload to `callbackUrl` at the end of a successful import when `directResponseVisualizationId` is set.
+- **feat**: Added `POST /callbacks/direct-response-visualization/:directResponseVisualizationId` callback endpoint.
+- **feat**: `POST /consumer/exchange` now returns the imported data under the `directResponseVisualization` key in the response when `directResponseVisualization: true`.
+- **feat**: Timeout behaviour controlled by the `EXCHANGE_TIMEOUT` environment variable (default 30 s).

--- a/docs/DIRECT_RESPONSE_VISUALIZATION.md
+++ b/docs/DIRECT_RESPONSE_VISUALIZATION.md
@@ -13,7 +13,7 @@ This is particularly useful for:
 - **Debugging and testing** data pipelines end-to-end.
 - **API-driven workflows** where the caller needs the data synchronously.
 - **Injecting custom data** through a service chain without requiring a live provider.
-- **Direct integration**  of the PDC data exchange requests
+- **Direct integration** of the PDC data exchange requests
 
 ---
 
@@ -63,7 +63,7 @@ A timeout (default **30 seconds**, configurable via the `EXCHANGE_TIMEOUT` envir
 
 ### 3. The exchange is initiated with the callback metadata
 
-The `directResponseVisualizationId` is forwarded to either `triggerBilateralFlow` or `triggerEcosystemFlow`. Both flows store two extra fields on the created `DataExchange` document:
+The `directResponseVisualizationId` is forwarded to either `triggerBilateralFlow` or `triggerEcosystemFlow`. Both flows store three extra fields on the created `DataExchange` document:
 
 | Field                           | Value                                                                                        |
 |---------------------------------|----------------------------------------------------------------------------------------------|
@@ -293,7 +293,7 @@ Existing endpoint — extended with the optional `directResponseVisualization` a
 | **`directResponseVisualization`** | `boolean` | ❌ | When `true`, the response waits and returns the exchanged data |
 | **`data`** | `array` | ❌ | Array of data objects to inject directly into the exchange, bypassing the provider export step. Compatible with both bilateral and service chain flows. |
 
-**Response (200) — with service chain**
+**Response (200) — service chain with injected `data`**
 ```json
 {
     "timestamp": 1783342073905,
@@ -422,19 +422,46 @@ Internal callback endpoint used by the consumer import service to resolve a pend
 
 ---
 
+## Backward Compatibility
+
+This feature was introduced in connector version **1.11.0**. The table below summarises the behaviour depending on the versions of the consumer and provider connectors involved in an exchange.
+
+| Consumer version | Provider version | `directResponseVisualization` | `data` field | Behaviour |
+|---|---|---|---|---|
+| ≥ 1.11.0 | ≥ 1.11.0 | ✅ Fully functional | ✅ Fully functional | All features work as described in this document. |
+| ≥ 1.11.0 | < 1.11.0 | ⚠️ Not functional but not blocking | ⚠️ Not functional — **blocking** if `resourceId` is omitted | The exchange is not blocked. However, if the consumer connector (≥ 1.11.0) triggers an exchange with `data` but without `resourceId`, the provider connector (< 1.11.0) cannot process the request and will respond with **Wrong resource given**, causing the exchange to fail. |
+| < 1.11.0 | any | ❌ Not available | ❌ Not available | The consumer connector does not support these fields. They are silently ignored and the exchange proceeds normally as a standard fire-and-forget exchange. **No exchange is blocked.** |
+
+### Key rules
+
+- **If either the consumer or the provider is on a version lower than 1.11.0, none of the features are functional** — but this does not block exchanges. The exchange completes normally as a standard fire-and-forget flow.
+- **The only blocking case** is when a ≥ 1.11.0 consumer sends the `data` field **without** `resourceId` to a provider on a lower version. Since the older provider cannot handle a request missing a resource reference, the exchange will fail. To stay safe when the provider version is unknown or older, always include `resourceId` alongside `data`.
+- **When a ≥ 1.11.0 consumer targets a < 1.11.0 provider** and uses `directResponseVisualization: true` (without `data`), the exchange proceeds normally but the feature is non-functional — the timeout elapses and the response returns `directResponseVisualization: null`.
+- **A consumer on a version lower than 1.11.0** does not expose the `directResponseVisualization` or `data` fields. Any client sending those fields to such a consumer will receive a standard exchange response — the exchange itself is unaffected.
+
+---
+
 ## Files Changed
 
-| File                                                      | Change                                                                                                                                                                                                                                                                                                             |
-|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `src/routes/public/v1/consumer.public.router.ts`          | Added `body('directResponseVisualization').isBoolean().optional()` and `body('data').isArray().optional()` validators to `/consumer/exchange`                                                                                                                                                                      |
-| `src/controllers/public/v1/consumer.public.controller.ts` | Added `directResponseVisualization` / `directResponseVisualizationId` / `callbackPromise` / `data` logic; returns `directResponseVisualization` payload in response                                                                                                                                                |
-| `src/services/public/v1/consumer.public.service.ts`       | `triggerBilateralFlow` and `triggerEcosystemFlow` now accept and store `directResponseVisualizationId`, `callbackUrl`, and `data` (boolean flag) on the `DataExchange` document; when `data` is provided the provider export is skipped; `consumerImportService` posts the imported data to `callbackUrl` when set |
-| `src/libs/loaders/pendingDirectResponseVisualization.ts`  | New file — exports the `pendingDirectResponseVisualizations` in-memory `Map` shared between the controller and the callback route                                                                                                                                                                                  |
-| `src/routes/public/v1/callback.public.router.ts`          | New route `POST /callbacks/direct-response-visualization/:directResponseVisualizationId` to resolve pending previews                                                                                                                                                                                               |
+| File | Change |
+|---|---|
+| `src/routes/public/v1/consumer.public.router.ts` | Added `body('directResponseVisualization').isBoolean().optional()` and `body('data').isArray().optional()` validators to `/consumer/exchange` |
+| `src/controllers/public/v1/consumer.public.controller.ts` | Added `directResponseVisualization` / `directResponseVisualizationId` / `callbackPromise` / `data` logic; returns `directResponseVisualization` payload in response |
+| `src/services/public/v1/consumer.public.service.ts` | `triggerBilateralFlow` and `triggerEcosystemFlow` now accept and store `directResponseVisualizationId`, `callbackUrl`, and `data` (boolean flag) on the `DataExchange` document; when `data` is provided the provider export is skipped; `consumerImportService` posts the imported data to `callbackUrl` when set |
+| `src/libs/loaders/pendingDirectResponseVisualization.ts` | New file — exports the `pendingDirectResponseVisualizations` in-memory `Map` shared between the controller and the callback route |
+| `src/routes/public/v1/callback.public.router.ts` | New route `POST /callbacks/direct-response-visualization/:directResponseVisualizationId` to resolve pending previews |
+| `src/models/DataExchange.ts` | Added `pdcVersion` field on the `DataExchange` document to store the connector version at exchange creation time, enabling backward compatibility checks |
 
 ---
 
 ## Changelog
+
+### 2026-07-08
+
+- **docs**: Added *Backward Compatibility* section documenting version interoperability rules between connector versions.
+- **docs**: Clarified that if either the consumer or the provider is on a version lower than 1.11.0, `directResponseVisualization` and `data` features are non-functional but do not block exchanges.
+- **docs**: Documented the only breaking case: a ≥ 1.11.0 consumer sending `data` without `resourceId` to a < 1.11.0 provider will cause the exchange to fail.
+- **feat**: Added `pdcVersion` field to the `DataExchange` document to store the connector version at exchange creation time, enabling backward compatibility checks.
 
 ### 2026-07-06
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ptx-dataspace-connector",
-    "version": "1.10.2",
+    "version": "1.11.0",
     "description": "Prometheus-X Data Space Connector",
     "main": "src/index.ts",
     "engines": {

--- a/src/controllers/public/v1/consumer.public.controller.ts
+++ b/src/controllers/public/v1/consumer.public.controller.ts
@@ -16,6 +16,7 @@ import { ExchangeError } from '../../../libs/errors/exchangeError';
 import axios from 'axios';
 import { verifyPayloadDefault } from '../../../utils/validation/payloadValidation';
 import { ObjectId } from 'mongodb';
+import {pendingDirectResponseVisualizations} from "../../../libs/loaders/pendingDirectResponseVisualization";
 
 /**
  * trigger the data exchange between provider and consumer in a bilateral or ecosystem contract
@@ -40,11 +41,34 @@ export const consumerExchange = async (
             purposes,
             serviceChainId,
             serviceChainParams,
+            data,
+            directResponseVisualization
         } = req.body;
 
         //Create a data Exchange
         let dataExchange: IDataExchange;
         let providerEndpoint: string;
+        let directResponseVisualizationId: any;
+        let callbackPromise: any;
+
+        const startTime = Date.now();
+        const parsedExchangeTimeout = Number(process.env.EXCHANGE_TIMEOUT);
+        const timeoutSeconds =
+            Number.isFinite(parsedExchangeTimeout) && parsedExchangeTimeout > 0
+                ? parsedExchangeTimeout
+                : 30;
+        const timeout = timeoutSeconds * 1000;
+
+        if(directResponseVisualization) {
+            directResponseVisualizationId = new ObjectId().toString();
+            callbackPromise = new Promise((resolve) => {
+                const timer = setTimeout(() => {
+                    pendingDirectResponseVisualizations.delete(directResponseVisualizationId);
+                }, timeout);
+
+                pendingDirectResponseVisualizations.set(directResponseVisualizationId, { resolve, timer });
+            });
+        }
 
         // ecosystem contract
         if (contract.includes('contracts')) {
@@ -61,6 +85,8 @@ export const consumerExchange = async (
                 consumerParams,
                 serviceChainId,
                 serviceChainParams,
+                directResponseVisualizationId,
+                data
             });
 
             dataExchange = ecosystemDataExchange;
@@ -77,6 +103,8 @@ export const consumerExchange = async (
                 consumerParams,
                 serviceChainId,
                 serviceChainParams,
+                directResponseVisualizationId,
+                data
             });
 
             dataExchange = bilateralDataExchange;
@@ -146,7 +174,8 @@ export const consumerExchange = async (
             );
 
             await ProviderExportService(
-                updatedDataExchange.consumerDataExchange
+                updatedDataExchange.consumerDataExchange,
+                data
             );
         } else {
             if (providerEndpoint === (await getEndpoint())) {
@@ -164,28 +193,37 @@ export const consumerExchange = async (
                 providerExport(providerEndpoint, dataExchange._id.toString())
             );
         }
-        const startTime = Date.now();
-        const parsedExchangeTimeout = Number(process.env.EXCHANGE_TIMEOUT);
-        const timeoutSeconds =
-            Number.isFinite(parsedExchangeTimeout) && parsedExchangeTimeout > 0
-                ? parsedExchangeTimeout
-                : 30;
-        const timeout = timeoutSeconds * 1000;
+
         let message: string;
         let success = false;
+        let callbackData: any;
         // return code 200 everything is ok
         while (dataExchange.status === 'PENDING') {
+
+            if (directResponseVisualization && directResponseVisualizationId && callbackPromise) {
+                try {
+                    callbackData = await callbackPromise;
+                    dataExchange = await DataExchange.findById(dataExchange._id);
+                } catch (err) {
+                    message = `${timeoutSeconds} sec Timeout reached.`;
+                    break;
+                }
+            }
+
             if (Date.now() - startTime > timeout) {
                 message = `${timeoutSeconds} sec Timeout reached.`;
                 break;
             }
+
             dataExchange = await DataExchange.findById(dataExchange._id);
+
             if (dataExchange.status === 'IMPORT_SUCCESS') {
                 success = true;
+                break;
             }
         }
 
-        return restfulResponse(res, 200, { success, dataExchange, message });
+        return restfulResponse(res, 200, { success, dataExchange, message, directResponseVisualization: callbackData });
     } catch (e) {
         Logger.error({
             message: e.message,

--- a/src/controllers/public/v1/consumer.public.controller.ts
+++ b/src/controllers/public/v1/consumer.public.controller.ts
@@ -61,13 +61,17 @@ export const consumerExchange = async (
 
         if(directResponseVisualization) {
             directResponseVisualizationId = new ObjectId().toString();
-            callbackPromise = new Promise((resolve) => {
+            callbackPromise = new Promise((resolve, reject) => {
                 const timer = setTimeout(() => {
                     pendingDirectResponseVisualizations.delete(directResponseVisualizationId);
+                    reject(new Error('Timeout reached'));
                 }, timeout);
 
-                pendingDirectResponseVisualizations.set(directResponseVisualizationId, { resolve, timer });
+                pendingDirectResponseVisualizations.set(directResponseVisualizationId, { resolve, reject, timer });
             });
+            // Prevent unhandled rejection crashes if the promise is never awaited
+            // (e.g. when the connector version check causes the callback path to be skipped)
+            callbackPromise.catch(() => {});
         }
 
         // ecosystem contract
@@ -199,15 +203,29 @@ export const consumerExchange = async (
         let callbackData: any;
         // return code 200 everything is ok
         while (dataExchange.status === 'PENDING') {
-
-            if (directResponseVisualization && directResponseVisualizationId && callbackPromise) {
+            if (
+                directResponseVisualization &&
+                directResponseVisualizationId &&
+                callbackPromise &&
+                (dataExchange.consumerPdcVersion >= "1.11.0" || dataExchange.providerPdcVersion >= "1.11.0")
+            ) {
                 try {
                     callbackData = await callbackPromise;
                     dataExchange = await DataExchange.findById(dataExchange._id);
                 } catch (err) {
-                    message = `${timeoutSeconds} sec Timeout reached.`;
+                    message = `${timeoutSeconds} sec Timeout directResponseVisualization reached.`;
+                    dataExchange = await DataExchange.findById(dataExchange._id);
                     break;
                 }
+            } else {
+                if (callbackPromise && directResponseVisualizationId) {
+                    const { timer } = pendingDirectResponseVisualizations.get(directResponseVisualizationId) || {};
+                    if (timer) {
+                        clearTimeout(timer);
+                        pendingDirectResponseVisualizations.delete(directResponseVisualizationId);
+                    }
+                }
+                callbackPromise = null;
             }
 
             if (Date.now() - startTime > timeout) {
@@ -216,11 +234,10 @@ export const consumerExchange = async (
             }
 
             dataExchange = await DataExchange.findById(dataExchange._id);
+        }
 
-            if (dataExchange.status === 'IMPORT_SUCCESS') {
-                success = true;
-                break;
-            }
+        if (dataExchange.status === 'IMPORT_SUCCESS') {
+            success = true;
         }
 
         return restfulResponse(res, 200, { success, dataExchange, message, directResponseVisualization: callbackData });

--- a/src/libs/loaders/configuration.ts
+++ b/src/libs/loaders/configuration.ts
@@ -11,6 +11,7 @@ import { Credential } from '../../utils/types/credential';
 import { urlChecker } from '../../utils/urlChecker';
 import { handle } from './handler';
 import { config } from '../../config/environment';
+import { version } from '../../../package.json';
 
 /**
  * Get the configuration file
@@ -178,6 +179,14 @@ const getExpressLimitSize = () => {
     } else {
         return null;
     }
+};
+
+/**
+ * Get the pdc version
+ * @returns The endpoint
+ */
+const getVersion = async () => {
+    return version;
 };
 
 /**
@@ -419,4 +428,5 @@ export {
     getRegistrationUri,
     getModalOrigins,
     getExpressLimitSize,
+    getVersion,
 };

--- a/src/libs/loaders/pendingDirectResponseVisualization.ts
+++ b/src/libs/loaders/pendingDirectResponseVisualization.ts
@@ -1,0 +1,1 @@
+export const pendingDirectResponseVisualizations = new Map();

--- a/src/routes/public/v1/callback.public.router.ts
+++ b/src/routes/public/v1/callback.public.router.ts
@@ -1,0 +1,50 @@
+import { Router } from 'express';
+import {pendingDirectResponseVisualizations} from "../../../libs/loaders/pendingDirectResponseVisualization";
+const r: Router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   name: DirectResponseVisualization
+ *   description: Data preview callback routes
+ */
+
+/**
+ * @swagger
+ * /direct-response-visualization/{directResponseVisualizationId}:
+ *   post:
+ *     summary: Resolve a pending data preview
+ *     description: Callback endpoint used to resolve a pending data preview request identified by its ID.
+ *     tags: [DirectResponseVisualization]
+ *     parameters:
+ *       - in: path
+ *         name: directResponseVisualizationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The unique identifier of the pending data preview
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: The data payload to resolve the preview with
+ *     responses:
+ *       '200':
+ *         description: Data preview successfully resolved
+ *       '404':
+ *         description: No pending data preview found for the given ID
+ */
+r.post('/direct-response-visualization/:directResponseVisualizationId', (req, res) => {
+    const entry = pendingDirectResponseVisualizations.get(req.params.directResponseVisualizationId);
+    if (!entry) return res.sendStatus(404);
+
+    clearTimeout(entry.timer);
+    pendingDirectResponseVisualizations.delete(req.params.directResponseVisualizationId);
+    entry.resolve(req.body);
+
+    res.sendStatus(200);
+});
+
+export default r;

--- a/src/routes/public/v1/consumer.public.router.ts
+++ b/src/routes/public/v1/consumer.public.router.ts
@@ -124,6 +124,8 @@ r.post(
         body('purposes').isArray().optional(),
         body('serviceChainId').isString().optional(),
         body('serviceChainParams').isArray().optional(),
+        body('directResponseVisualization').isBoolean().optional(),
+        body('data').optional(),
     ],
     consumerExchange
 );

--- a/src/routes/public/v1/exchange.public.router.ts
+++ b/src/routes/public/v1/exchange.public.router.ts
@@ -116,6 +116,8 @@ r.post(
         body('consumerParams').isArray().optional(),
         body('purposes').isArray().optional(),
         body('serviceChainParams').isArray().optional(),
+        body('directResponseVisualization').isBoolean().optional(),
+        body('data').optional(),
     ],
     consumerExchange
 );
@@ -231,6 +233,8 @@ r.post(
         body('consumerParams').isArray().optional(),
         body('purposes').isArray().optional(),
         body('serviceChainParams').isArray().optional(),
+        body('directResponseVisualization').isBoolean().optional(),
+        body('data').optional(),
     ],
     consumerExchange
 );

--- a/src/routes/public/v1/index.ts
+++ b/src/routes/public/v1/index.ts
@@ -8,6 +8,7 @@ import consumerPublicRouter from './consumer.public.router';
 import userPublicRouter from './user.public.router';
 import nodePublicRouter from './node.public.router';
 import exchangePublicRouter from './exchange.public.router';
+import callbackPublicRouter from "./callback.public.router";
 
 const routers = [
     {
@@ -49,6 +50,10 @@ const routers = [
     {
         prefix: '/exchange',
         router: exchangePublicRouter,
+    },
+    {
+        prefix: '/callbacks',
+        router: callbackPublicRouter,
     },
 ];
 

--- a/src/services/public/v1/consumer.public.service.ts
+++ b/src/services/public/v1/consumer.public.service.ts
@@ -8,7 +8,7 @@ import {
     IServiceChain,
     IParams,
 } from '../../../utils/types/dataExchange';
-import { getEndpoint } from '../../../libs/loaders/configuration';
+import {getEndpoint, getVersion} from '../../../libs/loaders/configuration';
 import { getCatalogData } from '../../../libs/third-party/catalog';
 import { ExchangeError } from '../../../libs/errors/exchangeError';
 import { getContract } from '../../../libs/third-party/contract';
@@ -303,6 +303,8 @@ export const triggerEcosystemFlow = async (props: {
                 consumerSelfDescriptionResponse?.dataspaceEndpoint,
             providerEndpoint:
             providerEndpoint,
+            consumerPdcVersion: await getVersion(),
+            providerPdcVersion: await getVersion(),
             resources: mappedDataResources,
             purposes: mappedSoftwareResources,
             purposeId: purposeId,

--- a/src/services/public/v1/consumer.public.service.ts
+++ b/src/services/public/v1/consumer.public.service.ts
@@ -18,6 +18,7 @@ import { postRepresentation } from '../../../libs/loaders/representationFetcher'
 import { providerImport } from '../../../libs/third-party/provider';
 import { getCredentialByIdService } from '../../private/v1/credential.private.service';
 import postgres from 'postgres';
+import {urlChecker} from "../../../utils/urlChecker";
 
 export const triggerBilateralFlow = async (props: {
     contract: string;
@@ -28,6 +29,8 @@ export const triggerBilateralFlow = async (props: {
     consumerParams?: IParams;
     serviceChainParams?: IParams;
     dataProcessingId?: string;
+    directResponseVisualizationId?: string;
+    data?: any
 }) => {
     const {
         resources,
@@ -36,43 +39,52 @@ export const triggerBilateralFlow = async (props: {
         consumerParams,
         serviceChainId,
         serviceChainParams,
+        directResponseVisualizationId,
+        data,
     } = props;
 
     const contract = props.contract;
+    let providerEndpoint: string;
+    let mappedDataResources: any;
 
     // retrieve contract
     const [contractResponse] = await handle(getContract(contract));
     // get Provider endpoint
-    const [providerResponse] = await handle(
-        axios.get(contractResponse.dataProvider)
-    );
 
-    const [resourceResponse] = await handle(
-        axios.get(contractResponse.serviceOffering)
-    );
+    if(!data){
+        const [providerResponse] = await handle(
+            axios.get(contractResponse.dataProvider)
+        );
+
+        if (!providerResponse?.dataspaceEndpoint) {
+            Logger.error({
+                message: 'Provider missing PDC endpoint',
+                location: 'consumerExchange',
+            });
+            throw new ExchangeError(
+                'Provider missing PDC endpoint',
+                'triggerBilateralFlow',
+                500
+            );
+        }
+
+        providerEndpoint = providerResponse?.dataspaceEndpoint;
+
+        const [resourceResponse] = await handle(
+            axios.get(contractResponse.serviceOffering)
+        );
+
+        mappedDataResources = resourcesMapper({
+            resources,
+            resourceResponse,
+            serviceOffering: contractResponse.serviceOffering,
+            type: 'dataResources',
+        });
+    }
 
     const [purposeResponse] = await handle(
         axios.get(contractResponse.purpose[0].purpose)
     );
-
-    if (!providerResponse?.dataspaceEndpoint) {
-        Logger.error({
-            message: 'Provider missing PDC endpoint',
-            location: 'consumerExchange',
-        });
-        throw new ExchangeError(
-            'Provider missing PDC endpoint',
-            'triggerBilateralFlow',
-            500
-        );
-    }
-
-    const mappedDataResources = resourcesMapper({
-        resources,
-        resourceResponse,
-        serviceOffering: contractResponse.serviceOffering,
-        type: 'dataResources',
-    });
 
     const mappedSoftwareResources = resourcesMapper({
         resources: purposes,
@@ -86,9 +98,9 @@ export const triggerBilateralFlow = async (props: {
 
     let dataExchange: IDataExchange;
 
-    if (providerResponse?.dataspaceEndpoint !== (await getEndpoint())) {
+    if (providerEndpoint !== (await getEndpoint())) {
         dataExchange = await DataExchange.create({
-            providerEndpoint: providerResponse?.dataspaceEndpoint,
+            providerEndpoint: providerEndpoint,
             resources: mappedDataResources,
             purposes: mappedSoftwareResources,
             purposeId: contractResponse.purpose[0].purpose,
@@ -97,6 +109,8 @@ export const triggerBilateralFlow = async (props: {
             providerParams: providerParams ?? [],
             consumerParams: consumerParams ?? [],
             createdAt: new Date(),
+            directResponseVisualizationId: directResponseVisualizationId ?? undefined,
+            callbackUrl: directResponseVisualizationId ? `${urlChecker(await getEndpoint(), `callbacks/direct-response-visualization/${directResponseVisualizationId}`)}` : undefined
         });
         // Create the data exchange at the provider
         await dataExchange.createDataExchangeToOtherParticipant('provider');
@@ -114,6 +128,8 @@ export const triggerBilateralFlow = async (props: {
             providerParams: providerParams ?? [],
             consumerParams: consumerParams ?? [],
             createdAt: new Date(),
+            directResponseVisualizationId: directResponseVisualizationId ?? undefined,
+            callbackUrl: directResponseVisualizationId ? `${urlChecker(await getEndpoint(), `callbacks/direct-response-visualization/${directResponseVisualizationId}`)}` : undefined
         });
         // Create the data exchange at the provider
         await dataExchange.createDataExchangeToOtherParticipant('consumer');
@@ -121,7 +137,7 @@ export const triggerBilateralFlow = async (props: {
 
     return {
         dataExchange,
-        providerEndpoint: providerResponse?.dataspaceEndpoint,
+        providerEndpoint: providerEndpoint,
     };
 };
 
@@ -135,6 +151,8 @@ export const triggerEcosystemFlow = async (props: {
     serviceChainId?: string;
     consumerParams?: IParams;
     serviceChainParams?: IParams;
+    directResponseVisualizationId?: string;
+    data?: any;
 }) => {
     const {
         contract,
@@ -144,6 +162,8 @@ export const triggerEcosystemFlow = async (props: {
         purposes,
         consumerParams,
         serviceChainParams,
+        directResponseVisualizationId,
+        data,
     } = props;
 
     let { resourceId, purposeId } = props;
@@ -151,6 +171,8 @@ export const triggerEcosystemFlow = async (props: {
     //Create a data Exchange
     let dataExchange: IDataExchange;
     let serviceChain: IServiceChain;
+    let providerEndpoint: string;
+    let mappedDataResources: any;
 
     // retrieve contract
     const [contractResponse] = await handle(getContract(contract));
@@ -179,9 +201,6 @@ export const triggerEcosystemFlow = async (props: {
     }
 
     //check if resource and purpose exists inside contract
-    const resourceExists = contractResponse.serviceOfferings.find(
-        (so: { serviceOffering: string }) => so.serviceOffering === resourceId
-    );
     const purposeExists = contractResponse.serviceOfferings.find(
         (so: { serviceOffering: string }) => so.serviceOffering === purposeId
     );
@@ -197,27 +216,56 @@ export const triggerEcosystemFlow = async (props: {
             500
         );
     }
-    if (!resourceExists) {
-        Logger.error({
-            message: 'Wrong resource given',
-            location: 'consumerExchange',
-        });
-        throw new ExchangeError(
-            'Wrong resource given',
-            'triggerEcosystemFlow',
-            500
+
+    if(!data){
+        const resourceExists = contractResponse.serviceOfferings.find(
+            (so: { serviceOffering: string }) => so.serviceOffering === resourceId
         );
+
+        if (!resourceExists) {
+            Logger.error({
+                message: 'Wrong resource given',
+                location: 'consumerExchange',
+            });
+            throw new ExchangeError(
+                'Wrong resource given',
+                'triggerEcosystemFlow',
+                500
+            );
+        }
+
+        const [serviceOfferingResponse] = await handle(getCatalogData(resourceId));
+
+        mappedDataResources = resourcesMapper({
+            resources,
+            resourceResponse: serviceOfferingResponse,
+            serviceOffering: resourceId,
+            type: 'dataResources',
+        });
+
+        // Verify PII
+        await verifyPII(mappedDataResources, purposeId);
+
+        //search Provider Endpoint
+        const providerSelfDescription = contractResponse.serviceOfferings.find(
+            (serviceOffering: any) => {
+                if (serviceOffering.serviceOffering === resourceId) {
+                    return serviceOffering;
+                } else return null;
+            }
+        );
+
+        const [providerSelfDescriptionResponse] = await handle(
+            axios.get(providerSelfDescription.participant)
+        );
+
+        providerEndpoint= providerSelfDescriptionResponse?.dataspaceEndpoint;
+
+    } else {
+        providerEndpoint = (await getEndpoint());
     }
 
-    const [serviceOfferingResponse] = await handle(getCatalogData(resourceId));
     const [purposeResponse] = await handle(getCatalogData(purposeId));
-
-    const mappedDataResources = resourcesMapper({
-        resources,
-        resourceResponse: serviceOfferingResponse,
-        serviceOffering: resourceId,
-        type: 'dataResources',
-    });
 
     const mappedSoftwareResources = resourcesMapper({
         resources: purposes,
@@ -238,28 +286,12 @@ export const triggerEcosystemFlow = async (props: {
         axios.get(consumerSelfDescription.participant)
     );
 
-    //search Provider Endpoint
-    const providerSelfDescription = contractResponse.serviceOfferings.find(
-        (serviceOffering: any) => {
-            if (serviceOffering.serviceOffering === resourceId) {
-                return serviceOffering;
-            } else return null;
-        }
-    );
-
-    const [providerSelfDescriptionResponse] = await handle(
-        axios.get(providerSelfDescription.participant)
-    );
-
-    // Verify PII
-    await verifyPII(mappedDataResources, purposeId);
-
     //case participant is provider and consumer
     //add all field to allow chain usage
     if (
         consumerSelfDescriptionResponse?.dataspaceEndpoint ===
             (await getEndpoint()) &&
-        providerSelfDescriptionResponse?.dataspaceEndpoint ===
+        providerEndpoint ===
             (await getEndpoint())
     ) {
         const id = new ObjectId();
@@ -270,7 +302,7 @@ export const triggerEcosystemFlow = async (props: {
             consumerEndpoint:
                 consumerSelfDescriptionResponse?.dataspaceEndpoint,
             providerEndpoint:
-                providerSelfDescriptionResponse?.dataspaceEndpoint,
+            providerEndpoint,
             resources: mappedDataResources,
             purposes: mappedSoftwareResources,
             purposeId: purposeId,
@@ -281,6 +313,9 @@ export const triggerEcosystemFlow = async (props: {
             serviceChainParams: serviceChainParams ?? [],
             createdAt: new Date(),
             serviceChain: serviceChain ?? [],
+            directResponseVisualizationId: directResponseVisualizationId ?? undefined,
+            callbackUrl: directResponseVisualizationId ? `${urlChecker(await getEndpoint(), `callbacks/direct-response-visualization/${directResponseVisualizationId}`)}` : undefined,
+            data: !!data
         });
     } else if (
         consumerSelfDescriptionResponse?.dataspaceEndpoint ===
@@ -289,7 +324,7 @@ export const triggerEcosystemFlow = async (props: {
         //search consumerEndpoint
         dataExchange = await DataExchange.create({
             providerEndpoint:
-                providerSelfDescriptionResponse?.dataspaceEndpoint,
+            providerEndpoint,
             resources: mappedDataResources,
             purposes: mappedSoftwareResources,
             purposeId: purposeId,
@@ -300,10 +335,13 @@ export const triggerEcosystemFlow = async (props: {
             serviceChainParams: serviceChainParams ?? [],
             createdAt: new Date(),
             serviceChain: serviceChain ?? [],
+            directResponseVisualizationId: directResponseVisualizationId ?? undefined,
+            callbackUrl: directResponseVisualizationId ? `${urlChecker(await getEndpoint(), `callbacks/direct-response-visualization/${directResponseVisualizationId}`)}` : undefined,
+            data: !!data
         });
         await dataExchange.createDataExchangeToOtherParticipant('provider');
     } else if (
-        providerSelfDescriptionResponse?.dataspaceEndpoint ===
+        providerEndpoint ===
         (await getEndpoint())
     ) {
         dataExchange = await DataExchange.create({
@@ -319,6 +357,9 @@ export const triggerEcosystemFlow = async (props: {
             serviceChainParams: serviceChainParams ?? [],
             createdAt: new Date(),
             serviceChain: serviceChain ?? [],
+            directResponseVisualizationId: directResponseVisualizationId ?? undefined,
+            callbackUrl: directResponseVisualizationId ? `${urlChecker(await getEndpoint(), `callbacks/direct-response-visualization/${directResponseVisualizationId}`)}` : undefined,
+            data: !!data
         });
 
         // Create the data exchange at the provider
@@ -327,7 +368,7 @@ export const triggerEcosystemFlow = async (props: {
 
     return {
         dataExchange,
-        providerEndpoint: providerSelfDescriptionResponse?.dataspaceEndpoint,
+        providerEndpoint: providerEndpoint,
     };
 };
 
@@ -588,6 +629,10 @@ export const consumerImportService = async (props: {
                     )
                 );
             }
+        }
+
+        if(dataExchange.directResponseVisualizationId && dataExchange.callbackUrl) {
+            axios.post(dataExchange.callbackUrl, consumerResponse)
         }
 
         await dataExchange?.updateStatus(DataExchangeStatusEnum.IMPORT_SUCCESS);

--- a/src/services/public/v1/data.public.service.ts
+++ b/src/services/public/v1/data.public.service.ts
@@ -207,13 +207,13 @@ export const exportDataService = async ({
                         dataExchange.serviceChain.services.length > 0
                     ) {
                         //Trigger the infrastructure flow
-                        await triggerInfrastructureFlowService(
-                            dataExchange.serviceChain,
+                        await triggerInfrastructureFlowService({
+                            serviceChain: dataExchange.serviceChain,
                             dataExchange,
                             data,
                             signedConsent,
                             encrypted
-                        );
+                        });
                     } else {
                         //Trigger the generic flow
                         await triggerGenericFlow({

--- a/src/services/public/v1/infrastructure.public.service.ts
+++ b/src/services/public/v1/infrastructure.public.service.ts
@@ -9,20 +9,20 @@ import { getAppKey, getEndpoint } from '../../../libs/loaders/configuration';
 
 /**
  * Trigger Infrastructure Flow Service
- * @param serviceChain
- * @param dataExchange
- * @param data
- * @param signedConsent
- * @param encrypted
+ * @param props
  */
-export const triggerInfrastructureFlowService = async (
-    serviceChain: ContractServiceChain,
-    dataExchange: IDataExchange,
-    data: any,
-    signedConsent?: any,
-    encrypted?: any
-) => {
+export const triggerInfrastructureFlowService = async (props: {
+     serviceChain: ContractServiceChain,
+     dataExchange: IDataExchange,
+     data: any,
+     signedConsent?: any,
+     encrypted?: any,
+     dataPayload?: boolean
+}) => {
     try {
+
+        const { serviceChain, dataExchange, data, signedConsent, encrypted, dataPayload } = props;
+
         // library implementation
         const nodeSupervisor = await SupervisorContainer.getInstance(
             await getAppKey()
@@ -38,6 +38,16 @@ export const triggerInfrastructureFlowService = async (
 
             // Find the participant endpoint
             const participantEndpoint = participantResponse.dataspaceEndpoint;
+
+            //case of directResponseVisualization and chain without data provider
+            if(dataPayload && participantEndpoint !== (await getEndpoint()) && index === 0) {
+                chainConfig.push({
+                    services: [],
+                    location: 'local',
+                    monitoringHost: await getEndpoint(),
+                    chainId: '',
+                });
+            }
 
             if (participantEndpoint === (await getEndpoint()) && index === 0) {
                 chainConfig.push({

--- a/src/services/public/v1/node.public.service.ts
+++ b/src/services/public/v1/node.public.service.ts
@@ -30,6 +30,7 @@ import { isJsonString } from '../../../utils/isJsonString';
 import {getConfigFile, getEndpoint} from '../../../libs/loaders/configuration';
 import { ServiceChainAdapterService } from './servicechainadapter.public.service';
 import { ObjectId } from 'mongodb';
+import axios from "axios";
 
 type CallbackMeta = PipelineMeta & {
     configuration: {
@@ -59,6 +60,7 @@ export const nodeCallbackService = async (props: {
         nextNodeResolver,
     } = props;
     let output: any;
+    let response = null;
     let decryptedConsent: IDecryptedConsent;
 
     const dataExchange = await DataExchange.findOne({
@@ -237,8 +239,6 @@ export const nodeCallbackService = async (props: {
                                 : {}),
                         };
 
-                        let response = null;
-
                         const payload = {
                             resource: resource[0]?.resource,
                             representationUrl:
@@ -262,7 +262,7 @@ export const nodeCallbackService = async (props: {
                             targetId,
                         };
 
-                        if (getConfigFile().serviceChainAdapter) {
+                        if (getConfigFile().serviceChainAdapter && nextTargetId) {
                             response = await new ServiceChainAdapterService(
                                 payload
                             ).processPotsOrPutRepresentationFlow();
@@ -304,6 +304,11 @@ export const nodeCallbackService = async (props: {
             await dataExchange.save();
 
             await dataExchange.completeServiceChain(targetId);
+
+            if(!nextTargetId && dataExchange.directResponseVisualizationId && dataExchange.callbackUrl){
+                axios.post(dataExchange.callbackUrl, response)
+            }
+
             return {
                 ...output,
             };

--- a/src/services/public/v1/provider.public.service.ts
+++ b/src/services/public/v1/provider.public.service.ts
@@ -27,13 +27,19 @@ interface IProviderExportServiceOptions {
 /**
  * Provider Export Service
  * @param consumerDataExchange
- * @param options
+ * @param dataPayload
  * @constructor
  */
 export const ProviderExportService = async (
     consumerDataExchange: string,
-    options?: IProviderExportServiceOptions
+    dataPayload?: any
 ) => {
+    let serviceOffering: string;
+    let contract: string;
+    let resource: string;
+    let endpointData: any;
+    let data: any;
+
     //Get the data exchange
     const dataExchange = await DataExchange.findOne({
         consumerDataExchange: consumerDataExchange,
@@ -43,229 +49,225 @@ export const ProviderExportService = async (
         // Get the contract
         const [contractResp] = await handle(getContract(dataExchange.contract));
 
-        const useServiceChain = dataExchange?.serviceChain &&
-            dataExchange?.serviceChain.services.length > 0
+        if(!dataPayload){
+            const useServiceChain = dataExchange?.serviceChain &&
+                dataExchange?.serviceChain.services.length > 0
 
-        const serviceOffering = selfDescriptionProcessor(
-            dataExchange.resources[0].serviceOffering,
-            dataExchange,
-            dataExchange.contract,
-            contractResp
-        );
+            serviceOffering = selfDescriptionProcessor(
+                dataExchange.resources[0].serviceOffering,
+                dataExchange,
+                dataExchange.contract,
+                contractResp
+            );
 
-        //PEP
-        const {
-            success: pep,
-            contractID,
-            resourceID,
-        } = await pepVerification({
-            targetResource: serviceOffering,
-            referenceURL: dataExchange.contract,
-        });
+            //PEP
+            const {
+                success: pep,
+                contractID,
+                resourceID,
+            } = await pepVerification({
+                targetResource: serviceOffering,
+                referenceURL: dataExchange.contract,
+            });
 
-        if (pep) {
-            for (const resource of dataExchange.resources) {
-                const resourceSD = resource.resource;
+            contract = contractID;
+            resource = resourceID;
 
-                // B to B exchange
-                if (
-                    dataExchange._id &&
-                    dataExchange.consumerEndpoint &&
-                    resourceSD
-                ) {
-                    //Call the catalog endpoint
-                    const [endpointData] = await handle(
-                        getCatalogData(resourceSD)
-                    );
+            if (pep) {
+                for (const resource of dataExchange.resources) {
+                    const resourceSD = resource.resource;
 
-                    if (!endpointData?.representation) {
-                        await consumerError(
-                            dataExchange.consumerEndpoint,
-                            dataExchange._id.toString(),
-                            'No representation found'
+                    // B to B exchange
+                    if (
+                        dataExchange._id &&
+                        dataExchange.consumerEndpoint &&
+                        resourceSD
+                    ) {
+                        //Call the catalog endpoint
+                        const [endpoint] = await handle(
+                            getCatalogData(resourceSD)
                         );
-                    }
 
-                    let data;
-                    let contentLength = 0;
-                    if (
-                        !endpointData?.representation?.url.match(
-                            Regexes.urlParams
-                        )
-                    ) {
-                        switch (endpointData?.representation?.type) {
-                            case 'REST': {
-                                const [getProviderData, responseHeaders] =
-                                    await handle(
-                                        getRepresentation({
-                                            resource: resourceSD,
-                                            method: endpointData?.representation
-                                                ?.method,
-                                            endpoint:
-                                                endpointData?.representation
-                                                    ?.url,
-                                            credential:
-                                                endpointData?.representation
-                                                    ?.credential,
-                                            representationQueryParams:
-                                                endpointData?.representation
-                                                    ?.queryParams,
-                                            proxy: endpointData?.representation
-                                                ?.proxy,
-                                            dataExchange,
-                                            mimeType:
-                                                endpointData?.representation
-                                                    ?.mimeType,
-                                        })
-                                    );
+                        endpointData = endpoint;
 
-                                data = getProviderData;
-
-                                if (!useServiceChain){
-                                    contentLength =
-                                        responseHeaders['content-length'];
-
-                                    if (!endpointData?.representation?.mimeType) {
-                                        Logger.info({
-                                            message: `No mimetype defined for ${resourceSD} in catalog, defaulting to application/json`,
-                                            location: 'ProviderExportService',
-                                        });
-                                    }
-
-                                    if (
-                                        endpointData?.representation?.mimeType &&
-                                        !responseHeaders['content-type']?.includes(
-                                            endpointData?.representation?.mimeType
-                                        )
-                                    ) {
-                                        throw new Error(
-                                            `Mimetype validation failed for ${resourceSD}, expected: ${endpointData?.representation?.mimeType}, got: ${responseHeaders['content-type']} from representation url`
-                                        );
-                                    }
-
-                                    if (
-                                        !endpointData?.representation?.mimeType?.includes(
-                                            'application/json'
-                                        )
-                                    ) {
-                                        await dataExchange.updateProviderData({
-                                            mimeType:
-                                            endpointData?.representation
-                                                ?.mimeType,
-                                            checksum: checksum(data),
-                                            size: responseHeaders['content-length'],
-                                        });
-                                    }
-                                }
-
-                                break;
-                            }
-
-                            case 'POSTGRESQL': {
-                                let cred;
-
-                                const sqlConfig =
-                                    endpointData?.representation?.sql;
-
-                                if (!sqlConfig.query) {
-                                    Logger.error({
-                                        message: `No SQL query defined for ${resourceSD} in catalog`,
-                                        location: 'ProviderExportService',
-                                    });
-                                    break;
-                                }
-
-                                if (!sqlConfig?.url) {
-                                    Logger.error({
-                                        message: `No URL defined for ${resourceSD} in catalog`,
-                                        location: 'ProviderExportService',
-                                    });
-                                    break;
-                                }
-
-                                if (sqlConfig?.credential) {
-                                    cred = await getCredentialByIdService(
-                                        sqlConfig?.credential
-                                    );
-                                }
-
-                                try {
-                                    const sql = postgres(sqlConfig?.url, {
-                                        host: sqlConfig?.host,
-                                        port: sqlConfig?.port,
-                                        database: sqlConfig?.database,
-                                        username: cred?.key,
-                                        password: cred?.value,
-                                    });
-
-                                    data = await sql.unsafe(sqlConfig?.query);
-                                    contentLength = data.length;
-
-                                    await sql.end();
-                                } catch (e) {
-                                    Logger.error({
-                                        message: `Error executing SQL for ${resourceSD}: ${e.message}`,
-                                        location: 'ProviderExportService',
-                                    });
-                                    await dataExchange?.updateStatus(
-                                        DataExchangeStatusEnum.PROVIDER_EXPORT_ERROR,
-                                        e.message,
-                                        await getEndpoint()
-                                    );
-
-                                    throw e;
-                                }
-
-                                break;
-                            }
-                        }
-                    }
-
-                    if (
-                        dataExchange?.serviceChain &&
-                        dataExchange?.serviceChain.services.length > 0
-                    ) {
-
-                        if (endpointData?.representation?.mimeType &&
-                            !endpointData?.representation?.mimeType?.includes('application/json') &&
-                            !endpointData?.representation?.mimeType?.includes('text/plain')) {
-                            throw new Error(
-                                `Mimetype validation failed for service chain, only 'application/json' or 'text/plain' supported, got: ${endpointData?.representation?.mimeType} for ${resourceSD}`
+                        if (!endpointData?.representation) {
+                            await consumerError(
+                                dataExchange.consumerEndpoint,
+                                dataExchange._id.toString(),
+                                'No representation found'
                             );
                         }
 
-                        //Trigger the infrastructure flow
-                        await triggerInfrastructureFlowService(
-                            dataExchange.serviceChain,
-                            dataExchange,
-                            data
-                        );
-                    } else {
-                        //Trigger the generic flow
-                        await triggerGenericFlow({
-                            dataExchange,
-                            data,
-                            serviceOffering,
-                            contractID,
-                            resourceID,
-                            endpointData,
-                        });
-                    }
-                    Logger.info({
-                        message: `Successfully retrieve data from ${resourceSD} with size of ${contentLength}Bytes`,
-                        location: 'ProviderExportService',
-                    });
-                }
-            }
+                        let contentLength = 0;
+                        if (
+                            !endpointData?.representation?.url.match(
+                                Regexes.urlParams
+                            )
+                        ) {
+                            switch (endpointData?.representation?.type) {
+                                case 'REST': {
+                                    const [getProviderData, responseHeaders] =
+                                        await handle(
+                                            getRepresentation({
+                                                resource: resourceSD,
+                                                method: endpointData?.representation
+                                                    ?.method,
+                                                endpoint:
+                                                endpointData?.representation
+                                                    ?.url,
+                                                credential:
+                                                endpointData?.representation
+                                                    ?.credential,
+                                                representationQueryParams:
+                                                endpointData?.representation
+                                                    ?.queryParams,
+                                                proxy: endpointData?.representation
+                                                    ?.proxy,
+                                                dataExchange,
+                                                mimeType:
+                                                endpointData?.representation
+                                                    ?.mimeType,
+                                            })
+                                        );
 
-            return true;
+                                    data = getProviderData;
+
+                                    if (!useServiceChain){
+                                        contentLength =
+                                            responseHeaders['content-length'];
+
+                                        if (!endpointData?.representation?.mimeType) {
+                                            Logger.info({
+                                                message: `No mimetype defined for ${resourceSD} in catalog, defaulting to application/json`,
+                                                location: 'ProviderExportService',
+                                            });
+                                        }
+
+                                        if (
+                                            endpointData?.representation?.mimeType &&
+                                            !responseHeaders['content-type']?.includes(
+                                                endpointData?.representation?.mimeType
+                                            )
+                                        ) {
+                                            throw new Error(
+                                                `Mimetype validation failed for ${resourceSD}, expected: ${endpointData?.representation?.mimeType}, got: ${responseHeaders['content-type']} from representation url`
+                                            );
+                                        }
+
+                                        if (
+                                            !endpointData?.representation?.mimeType?.includes(
+                                                'application/json'
+                                            )
+                                        ) {
+                                            await dataExchange.updateProviderData({
+                                                mimeType:
+                                                endpointData?.representation
+                                                    ?.mimeType,
+                                                checksum: checksum(data),
+                                                size: responseHeaders['content-length'],
+                                            });
+                                        }
+                                    }
+
+                                    break;
+                                }
+
+                                case 'POSTGRESQL': {
+                                    let cred;
+
+                                    const sqlConfig =
+                                        endpointData?.representation?.sql;
+
+                                    if (!sqlConfig.query) {
+                                        Logger.error({
+                                            message: `No SQL query defined for ${resourceSD} in catalog`,
+                                            location: 'ProviderExportService',
+                                        });
+                                        break;
+                                    }
+
+                                    if (!sqlConfig?.url) {
+                                        Logger.error({
+                                            message: `No URL defined for ${resourceSD} in catalog`,
+                                            location: 'ProviderExportService',
+                                        });
+                                        break;
+                                    }
+
+                                    if (sqlConfig?.credential) {
+                                        cred = await getCredentialByIdService(
+                                            sqlConfig?.credential
+                                        );
+                                    }
+
+                                    try {
+                                        const sql = postgres(sqlConfig?.url, {
+                                            host: sqlConfig?.host,
+                                            port: sqlConfig?.port,
+                                            database: sqlConfig?.database,
+                                            username: cred?.key,
+                                            password: cred?.value,
+                                        });
+
+                                        data = await sql.unsafe(sqlConfig?.query);
+                                        contentLength = data.length;
+
+                                        await sql.end();
+                                    } catch (e) {
+                                        Logger.error({
+                                            message: `Error executing SQL for ${resourceSD}: ${e.message}`,
+                                            location: 'ProviderExportService',
+                                        });
+                                        await dataExchange?.updateStatus(
+                                            DataExchangeStatusEnum.PROVIDER_EXPORT_ERROR,
+                                            e.message,
+                                            await getEndpoint()
+                                        );
+
+                                        throw e;
+                                    }
+
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                await dataExchange?.updateStatus(
+                    DataExchangeStatusEnum.PEP_ERROR,
+                    "The policies can't be verified",
+                    await getEndpoint()
+                );
+            }
         } else {
-            await dataExchange?.updateStatus(
-                DataExchangeStatusEnum.PEP_ERROR,
-                "The policies can't be verified",
-                await getEndpoint()
-            );
+            data = dataPayload
         }
+
+        if (
+            dataExchange?.serviceChain &&
+            dataExchange?.serviceChain.services.length > 0
+        ) {
+
+            //Trigger the infrastructure flow
+            await triggerInfrastructureFlowService({
+                serviceChain: dataExchange.serviceChain,
+                dataExchange,
+                data,
+                dataPayload: !!dataPayload
+            });
+        } else {
+            //Trigger the generic flow
+            await triggerGenericFlow({
+                dataExchange,
+                data,
+                serviceOffering,
+                contractID: contract,
+                resourceID: resource,
+                endpointData,
+            });
+        }
+        return true;
     } catch (e) {
         Logger.error({
             message: e.message,
@@ -304,7 +306,7 @@ const triggerGenericFlow = async (props: {
             )
         );
 
-        if (consumerImportRes) {
+        if (consumerImportRes && !props.dataExchange.data) {
             const names = await pepLeftOperandsVerification({
                 targetResource: props.serviceOffering,
             });

--- a/src/tests/services/infrastructure.public.service.spec.ts
+++ b/src/tests/services/infrastructure.public.service.spec.ts
@@ -73,7 +73,7 @@ describe('Infrastructure API tests', () => {
             sinon.stub(configLoader, 'getAppKey').resolves('appkey');
             sinon.stub(configLoader, 'getEndpoint').resolves('https://dataspace.test.com');
 
-            const response = await triggerInfrastructureFlowService(serviceChain, dataExchange, data);
+            const response = await triggerInfrastructureFlowService({serviceChain, dataExchange, data});
             expect(response).equal(true);
         });
     });

--- a/src/tests/services/servicechainadapter.public.service.spec.ts
+++ b/src/tests/services/servicechainadapter.public.service.spec.ts
@@ -33,9 +33,10 @@ describe('ServiceChainAdapterService', () => {
         const service = new ServiceChainAdapterService(payload);
         const result = await service.processGetRepresentationFlow();
 
+
         expect(result).to.deep.equal({ status: 200, message: 'ACK' });
         expect(getRepresentationStub.calledOnce).to.be.true;
-        await new Promise(res => setTimeout(res, 10));
+        await new Promise(res => setTimeout(res, 100));
         expect(resumeNodeSpy.calledOnce).to.be.true;
     });
 
@@ -48,7 +49,7 @@ describe('ServiceChainAdapterService', () => {
 
         expect(result).to.deep.equal({ status: 200, message: 'ACK' });
         expect(postOrPutStub.calledOnce).to.be.true;
-        await new Promise(res => setTimeout(res, 10));
+        await new Promise(res => setTimeout(res, 100));
         expect(resumeNodeSpy.calledOnce).to.be.true;
     });
 

--- a/src/utils/types/dataExchange.ts
+++ b/src/utils/types/dataExchange.ts
@@ -65,6 +65,9 @@ interface IDataExchange {
     consumerParams?: IParams;
     serviceChain?: ContractServiceChain;
     serviceChainParams?: [IData];
+    directResponseVisualizationId?: string;
+    callbackUrl?: string;
+    data?: boolean;
 
     // Define method signatures
     createDataExchangeToOtherParticipant(
@@ -164,6 +167,9 @@ const schema = new Schema({
             },
         ],
     },
+    directResponseVisualizationId: String,
+    callbackUrl: String,
+    data: Boolean,
 });
 
 /**
@@ -189,6 +195,9 @@ schema.methods.createDataExchangeToOtherParticipant = async function (
             consumerDataExchange: this._id,
             serviceChain: this.serviceChain,
             providerData: this.providerData,
+            directResponseVisualizationId: this.directResponseVisualizationId,
+            callbackUrl: this.callbackUrl,
+            data: this.data,
         };
     } else {
         data = {
@@ -205,6 +214,9 @@ schema.methods.createDataExchangeToOtherParticipant = async function (
             providerDataExchange: this._id,
             serviceChain: this.serviceChain,
             providerData: this.providerData,
+            directResponseVisualizationId: this.directResponseVisualizationId,
+            callbackUrl: this.callbackUrl,
+            data: this.data,
         };
     }
     const response = await axios.post(
@@ -280,6 +292,9 @@ schema.methods.syncWithInfrastructure = async function (
             providerDataExchange: this.providerDataExchange,
             providerEndpoint: this.providerEndpoint,
             providerData: this.providerData,
+            directResponseVisualizationId: this.directResponseVisualizationId,
+            callbackUrl: this.callbackUrl,
+            data: this.data,
         })
     );
 

--- a/src/utils/types/dataExchange.ts
+++ b/src/utils/types/dataExchange.ts
@@ -1,7 +1,7 @@
 import { connection, Schema } from 'mongoose';
 import axios from 'axios';
 import { urlChecker } from '../urlChecker';
-import { getEndpoint } from '../../libs/loaders/configuration';
+import {getEndpoint, getVersion} from '../../libs/loaders/configuration';
 import { ObjectId } from 'mongodb';
 import { handle } from '../../libs/loaders/handler';
 import { ContractServiceChain } from './contractServiceChain';
@@ -38,11 +38,13 @@ export interface IServiceChain {
 interface IDataExchange {
     _id: ObjectId;
     providerEndpoint: string;
+    providerPdcVersion: string;
     resources: [IData];
     purposes: [IData];
     purposeId?: string;
     contract: string;
     consumerEndpoint?: string;
+    consumerPdcVersion?: string;
     consumerDataExchange?: string;
     providerDataExchange?: string;
     status: string;
@@ -130,6 +132,8 @@ const schema = new Schema({
     contract: String,
     consumerEndpoint: String,
     providerEndpoint: String,
+    consumerPdcVersion: String,
+    providerPdcVersion: String,
     consumerDataExchange: String,
     providerDataExchange: String,
     providerData: {
@@ -183,6 +187,7 @@ schema.methods.createDataExchangeToOtherParticipant = async function (
     if (participant === 'provider') {
         data = {
             consumerEndpoint: await getEndpoint(),
+            consumerPdcVersion: await getVersion(),
             resources: this.resources,
             purposes: this.purposes,
             purposeId: this.purposeId,
@@ -202,6 +207,7 @@ schema.methods.createDataExchangeToOtherParticipant = async function (
     } else {
         data = {
             providerEndpoint: await getEndpoint(),
+            providerPdcVersion: await getVersion(),
             resources: this.resources,
             purposes: this.purposes,
             purposeId: this.purposeId,
@@ -219,6 +225,25 @@ schema.methods.createDataExchangeToOtherParticipant = async function (
             data: this.data,
         };
     }
+
+    try{
+        const participantPdcSelfDescription = await axios.get(
+            participant === 'provider'
+                ? this.providerEndpoint
+                : this.consumerEndpoint,
+        );
+
+        const participantPdcVersion = participantPdcSelfDescription.data.content["ptx:version"]
+
+        if(participant === 'provider'){
+            this.providerPdcVersion = participantPdcVersion;
+        } else {
+            this.consumerPdcVersion = participantPdcVersion;
+        }
+    } catch (error) {
+        console.error(`Failed to fetch PDC version from ${participant} endpoint:`, error);
+    }
+
     const response = await axios.post(
         urlChecker(
             participant === 'provider'


### PR DESCRIPTION
This pull request introduces support for direct response visualizations in the data exchange workflow, enabling asynchronous preview callbacks and improving the handling of data previews. It also exposes the connector version programmatically and updates request validation to support the new fields. The main changes are divided into three themes:

**Direct Response Visualization Workflow:**

* Added a mechanism to handle pending direct response visualizations using a shared `Map` (`pendingDirectResponseVisualizations`), including timeout and callback resolution logic in `consumerExchange` (`src/controllers/public/v1/consumer.public.controller.ts`, `src/libs/loaders/pendingDirectResponseVisualization.ts`). [[1]](diffhunk://#diff-cc5cf1c042025a58116f339a7ef47ced9197169dd75f70c2324b8174c5b0bd57R44-R75) [[2]](diffhunk://#diff-cc5cf1c042025a58116f339a7ef47ced9197169dd75f70c2324b8174c5b0bd57L167-R243) [[3]](diffhunk://#diff-7a639139200a0df24fe578618216b9231b21e1ba2edc781e5312c90213706f9bR1)
* Introduced a new callback endpoint `/callbacks/direct-response-visualization/:directResponseVisualizationId` to resolve pending visualizations, with Swagger documentation and integration into the router (`src/routes/public/v1/callback.public.router.ts`, `src/routes/public/v1/index.ts`). [[1]](diffhunk://#diff-5bc6d88672dc4d6306ff49a927f53d03e1a2ea2f606764c3683ad87f8b874f38R1-R50) [[2]](diffhunk://#diff-970740da8e3c27bd53c44cce9d8fb4582edfb9e75c2ba9a60a2678b44d3e774dR11) [[3]](diffhunk://#diff-970740da8e3c27bd53c44cce9d8fb4582edfb9e75c2ba9a60a2678b44d3e774dR54-R57)

**API and Service Changes:**

* Updated the consumer exchange and bilateral/ecosystem flow services to accept and propagate `directResponseVisualization` and `data` fields, set up callback URLs, and handle new logic for direct response visualizations (`src/services/public/v1/consumer.public.service.ts`). [[1]](diffhunk://#diff-5be2ee793427f761eab1d43013fca76872f3e3776f2fb7d9075f55964d754621R32-R33) [[2]](diffhunk://#diff-5be2ee793427f761eab1d43013fca76872f3e3776f2fb7d9075f55964d754621R42-L57) [[3]](diffhunk://#diff-5be2ee793427f761eab1d43013fca76872f3e3776f2fb7d9075f55964d754621R112-R113) [[4]](diffhunk://#diff-5be2ee793427f761eab1d43013fca76872f3e3776f2fb7d9075f55964d754621R131-R140) [[5]](diffhunk://#diff-5be2ee793427f761eab1d43013fca76872f3e3776f2fb7d9075f55964d754621R154-R155) [[6]](diffhunk://#diff-5be2ee793427f761eab1d43013fca76872f3e3776f2fb7d9075f55964d754621R165-R175)
* Enhanced request validation to support the new fields in all relevant endpoints (`src/routes/public/v1/consumer.public.router.ts`, `src/routes/public/v1/exchange.public.router.ts`). [[1]](diffhunk://#diff-cc1fd467a6cc208187e40a66b02074adb87275de689312991ca873551787cb77R127-R128) [[2]](diffhunk://#diff-daa4e94512c0290f92c0315583191db6884e2e9f9100f91107d7ddc9d5ca624cR119-R120) [[3]](diffhunk://#diff-daa4e94512c0290f92c0315583191db6884e2e9f9100f91107d7ddc9d5ca624cR236-R237)

**Version Exposure:**

* Added a new `getVersion` function to expose the connector version programmatically, and updated `package.json` to version `1.11.0` (`src/libs/loaders/configuration.ts`, `package.json`). [[1]](diffhunk://#diff-b198495ac7067d405f4548b2163497e54cd11105471d7f48a3f42784a53ad14bR14) [[2]](diffhunk://#diff-b198495ac7067d405f4548b2163497e54cd11105471d7f48a3f42784a53ad14bR184-R191) [[3]](diffhunk://#diff-b198495ac7067d405f4548b2163497e54cd11105471d7f48a3f42784a53ad14bR431) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)